### PR TITLE
docs: documentation website (MkDocs Material + GitHub Pages)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,60 @@
+name: Deploy documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "overrides/**"
+      - "mkdocs.yml"
+      - "requirements-docs.txt"
+      - "src/**"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; cancel in-progress runs for newer pushes.
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # needed for git-based "last updated" if enabled later
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install docs toolchain
+        run: pip install -r requirements-docs.txt
+
+      - name: Build site (strict)
+        run: mkdocs build --strict
+
+      - uses: actions/configure-pages@v5
+        with:
+          enablement: true
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ CLAUDE.md
 # Private audit notes
 AUDIT.md
 .claude/
+
+# Docs build
+site/
+.venv-docs/

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -1,0 +1,207 @@
+# Contributing & Developer Setup
+
+bharat-courts is free, open-source software and contributions are welcome —
+bug reports, fixes, more court coverage, better CAPTCHA solving, and docs all
+help. This page gets you from a fresh clone to a green test run.
+
+The code lives on GitHub at
+[github.com/iamshouvikmitra/bharat-courts](https://github.com/iamshouvikmitra/bharat-courts).
+Open issues and pull requests there.
+
+!!! info "Audience"
+    This is an engineer-facing page. If you just want to *use* the library,
+    start at [Installation](../start/installation.md) and the
+    [Quickstart](../start/quickstart.md). If you want to use it through an AI
+    assistant, see the [lawyers' guides](../lawyers/index.md).
+
+## Prerequisites
+
+- **Python 3.11+** — check with `python3 --version`. If your system Python is
+  older, use `python3.12` explicitly in the commands below.
+- **git**
+
+## Dev environment setup
+
+Fork the repo on GitHub, then clone your fork:
+
+```bash
+# 1. Clone (swap in your fork's URL)
+git clone https://github.com/<your-username>/bharat-courts.git
+cd bharat-courts
+
+# 2. Create and activate a virtual environment
+python3 -m venv .venv
+source .venv/bin/activate     # Linux/macOS
+# .venv\Scripts\activate      # Windows
+
+# 3. Editable install with all extras (OCR + ONNX + CLI + archive + dev tools)
+pip install -e ".[all]"
+
+# 4. Verify everything works
+pytest
+ruff check . && ruff format --check .
+```
+
+`pip install -e ".[all]"` installs the package in editable mode with every
+optional extra, so you can work on any backend — live clients, the archive, the
+CLI — without reinstalling.
+
+!!! tip "Older system Python"
+    If `python3 --version` reports 3.10 or earlier, substitute `python3.12`
+    when creating the virtual environment:
+
+    ```bash
+    python3.12 -m venv .venv
+    ```
+
+## Running tests
+
+The unit suite is **250 tests and runs entirely offline** — no network, no
+CAPTCHA, no AWS. It should pass on a fresh clone in seconds.
+
+```bash
+# Full unit suite (fast, offline)
+pytest
+
+# A single test file
+pytest tests/test_hcservices_parser.py
+
+# A single test
+pytest tests/test_hcservices_parser.py::test_parse_case_status_json
+
+# Verbose output
+pytest -v
+```
+
+### Live integration tests
+
+The `tests/integration/` directory holds **standalone scripts** that hit the
+real eCourts portals and the real AWS Open Data buckets. They are **not
+collected by `pytest`** (the default `python_files=test_*.py` pattern does not
+match them), so you invoke them directly. They need network access, and the
+portal-facing ones need a CAPTCHA solver (install the `[ocr]` extra, included in
+`[all]`). Each script prints PASS/FAIL and exits non-zero on failure, which
+makes them useful for pre-release validation.
+
+```bash
+python tests/integration/hcservices.py            # HC Services portal + CAPTCHA
+python tests/integration/archive.py               # archive + facade vs real S3
+python tests/integration/districtcourts.py        # District Courts portal
+python tests/integration/calcuttahc_wpa_12886.py  # Calcutta HC regression case
+```
+
+See `tests/integration/README.md` for the full list and details.
+
+!!! warning "Integration tests touch live services"
+    Because they scrape real portals, integration runs are slower, rate-limited,
+    and can fail for reasons outside your change (portal downtime, a CAPTCHA
+    miss, an upstream HTML tweak). Treat a unit-suite pass as the bar for a PR;
+    run the relevant integration script when you have changed a backend that
+    talks to that portal.
+
+## Linting and formatting
+
+The project uses [ruff](https://docs.astral.sh/ruff/) for both linting and
+formatting.
+
+```bash
+# Check for lint issues
+ruff check .
+
+# Auto-fix what ruff can fix
+ruff check --fix .
+
+# Check formatting without writing
+ruff format --check .
+
+# Reformat the codebase
+ruff format .
+```
+
+Config lives in `pyproject.toml`: Python 3.11 target, 100-character line length,
+rule sets `E`, `F`, `I`, `N`, `W`.
+
+## Source layout
+
+All package code is under `src/bharat_courts/` (a `src/` layout, which prevents
+accidental imports of the working tree during development). The headline
+modules:
+
+| Path | What it holds |
+|------|---------------|
+| `models.py` | All DTO dataclasses (`Court`, `CaseInfo`, `CaseOrder`, `CauseListPDF`, `JudgmentResult`, `Judgment`, `SearchResult`) with `to_dict()` / `to_json()`. |
+| `courts.py` | Static registry of every court + eCourts state codes; `get_court()`, `get_court_by_state_code()`, `infer_court_from_cnr()`. |
+| `config.py` | Pydantic Settings with the `BHARAT_COURTS_` env prefix; a module-level `config` singleton. |
+| `http.py` | `RateLimitedClient` wrapping httpx (retry, rate limiting, SSL bypass, browser-like headers) for the live clients. |
+| `captcha/` | Pluggable solving: `CaptchaSolver` ABC → `ManualCaptchaSolver`, `OCRCaptchaSolver` (ddddocr), `ONNXCaptchaSolver`. |
+| `hcservices/` | Primary live client for `hcservices.ecourts.gov.in`. |
+| `districtcourts/` | Live client for `services.ecourts.gov.in` (700+ courts). |
+| `calcuttahc/` | Direct-website client for `calcuttahighcourt.gov.in`. |
+| `judgments/` | Live client for `judgments.ecourts.gov.in`. |
+| `sci/` | Live client for `www.sci.gov.in` (homepage feed). |
+| `archive/` | Opt-in (`[archive]` extra): DuckDB over the AWS Open Data parquet shards + PDF caching. |
+| `facade.py` | `Judgments` — the federated `find()` / `fetch_pdf()` entry point that routes archive vs live. |
+| `cli.py` | Click CLI entry point; command groups mirror the SDK module names. |
+
+The clients in `hcservices/`, `districtcourts/`, `calcuttahc/`, and `judgments/`
+each follow the same internal split — `client.py` (the public class),
+`endpoints.py` (URL and form builders), `parser.py` (response parsers).
+
+For deeper architectural background see [How it works](how-it-works.md) and the
+[data sources](data-sources.md) page.
+
+## Testing approach
+
+Knowing how the suite is built makes it easier to add tests for your change:
+
+- **HTTP is mocked with [respx](https://lundberg.github.io/respx/)**, which
+  hooks into httpx natively. Parser tests feed recorded HTML/JSON fixtures from
+  `tests/fixtures/` through the parsers.
+- **CAPTCHA in tests** is handled by a custom `CaptchaSolver` subclass that
+  returns a fixed string, so live-client tests never touch a real solver.
+- **Archive tests** build **synthetic in-memory tars** and `respx`-mocked HTTP
+  instead of hitting S3, and stub the DuckDB query / cache layer with
+  `AsyncMock` + `unittest.mock.patch.object`.
+- **Facade tests** stub both backends with `AsyncMock` so the routing decision
+  matrix is exercised without touching either S3 or the live portal.
+
+!!! note "respx caveat"
+    respx does not support `host__icontains` matchers — use `url__regex`
+    instead when matching by host.
+
+## Areas where help is needed
+
+A few concrete places where contributions would land well:
+
+- **Better CAPTCHA solving** — ddddocr is ~75% accurate on the judgments portal;
+  the ONNX solver is an alternative, but a fine-tuned model would help further.
+- **District court reliability** — broader coverage testing across more
+  states/complexes; `case_status_by_party` still has no pagination.
+- **Supreme Court case search** — `SCIClient.search_by_year` /
+  `search_by_party` are stubbed; the live `www.sci.gov.in` portal has a
+  CAPTCHA-protected case-no/diary-no/party-name form that needs wiring up.
+- **HC Services case history** — `case_status` does not return Pending/Disposed
+  (or registration date / next hearing) because the SDK hits `showRecords`
+  only; calling `o_civil_case_history.php` afterwards would fill in the rest.
+- **More High Court coverage** — testing against courts beyond Delhi, Bombay,
+  and Allahabad.
+- **Documentation** — more examples and tutorials.
+
+## Submitting changes
+
+1. Fork the repo and create a branch: `git checkout -b my-feature`.
+2. Make your changes.
+3. Run `pytest` and `ruff check .` to confirm tests pass and the code is clean.
+4. Commit with a descriptive message.
+5. Open a pull request against
+   [iamshouvikmitra/bharat-courts](https://github.com/iamshouvikmitra/bharat-courts).
+
+Bug reports and feature requests are equally welcome on the
+[issue tracker](https://github.com/iamshouvikmitra/bharat-courts/issues).
+
+## License
+
+bharat-courts is released under the [MIT License](https://github.com/iamshouvikmitra/bharat-courts/blob/main/LICENSE).
+Note that the historical **archive data** itself is CC-BY-4.0 — attribute Dattam
+Labs / the eCourts platform when you redistribute it. See
+[Data sources](data-sources.md) for details.

--- a/docs/about/data-sources.md
+++ b/docs/about/data-sources.md
@@ -1,0 +1,158 @@
+# Data Sources & Licensing
+
+bharat-courts does not host any court data of its own. It is a thin, open-source
+layer over public Indian court data — the official eCourts portals on one side,
+and a public AWS Open Data archive on the other. This page explains exactly where
+the data comes from, how current it is, how it is licensed, and how to attribute it
+when you republish it.
+
+For the mechanics of how the two backends are wired together, see
+[How it works](how-it-works.md).
+
+## Two kinds of source
+
+bharat-courts reads from two complementary kinds of source:
+
+- **Live sources** — the official eCourts and court websites. These reflect the
+  *current* state of a case: status, next hearing, cause lists, freshly uploaded
+  orders. They are CAPTCHA-gated and rate-limited.
+- **Historical archive** — two public AWS Open Data S3 buckets mirroring decided
+  judgments back to 1950. No CAPTCHA, no rate limits, but the data lags real time
+  by a couple of months.
+
+!!! tip "Which one answers my question?"
+    Use the **live** sources for "what is happening *now*" — case status, next
+    hearing date, today's cause list, an order uploaded this week. Use the
+    **archive** for historical research and bulk retrieval of *decided* judgments.
+    The `Judgments` facade picks between them for you on most queries.
+
+## Live sources
+
+These are the official portals bharat-courts scrapes. Each has its own client in
+the SDK.
+
+| Source | Portal | Client | What it provides |
+|---|---|---|---|
+| High Court Services | [hcservices.ecourts.gov.in](https://hcservices.ecourts.gov.in) | `HCServicesClient` | High Court case status, orders, cause lists, bench/case-type discovery |
+| District Courts | [services.ecourts.gov.in](https://services.ecourts.gov.in) | `DistrictCourtClient` | District court case status, orders, cause lists across 700+ court complexes |
+| Judgment Search | [judgments.ecourts.gov.in](https://judgments.ecourts.gov.in) | `JudgmentSearchClient` | Full-text keyword search of High Court judgments, with PDF download |
+| Supreme Court | [www.sci.gov.in](https://www.sci.gov.in) | `SCIClient` | The homepage "Latest Judgements / Orders" feed and PDF download |
+| Calcutta High Court | [calcuttahighcourt.gov.in](https://calcuttahighcourt.gov.in) | `CalcuttaHCClient` | Order/judgment search direct from the court's own site (better Calcutta HC PDF coverage from September 2020 onwards) |
+
+!!! info "Update cadence: live = real-time"
+    Live sources are queried on demand and reflect whatever the portal shows at
+    that moment. There is no caching delay on the data itself — if the court has
+    updated a record, the live client sees it.
+
+!!! note "Known live-source limitations"
+    A few flows are not yet wired up, and bharat-courts is honest about this rather
+    than guessing:
+
+    - The Supreme Court client surfaces the recent-judgments feed and PDF download;
+      `SCIClient.search_by_year(...)` and `search_by_party(...)` raise
+      `NotImplementedError` (the legacy host they used is permanently offline and the
+      replacement form is CAPTCHA-gated).
+    - The HC Services `showRecords` endpoint does not return case *status*,
+      `registration_date`, `judges`, or `next_hearing_date`, so those fields stay
+      empty on results from that path.
+
+## Historical archive (AWS Open Data)
+
+For research and bulk work, `ArchiveClient` reads two public S3 buckets in the
+AWS Open Data programme. **No CAPTCHA, no rate limits, no AWS account needed.**
+They require the archive extra (`pip install 'bharat-courts[archive]'`).
+
+| Bucket | Contents | Registry |
+|---|---|---|
+| `indian-supreme-court-judgments` | Supreme Court of India, **1950 → present** | [registry.opendata.aws](https://registry.opendata.aws/indian-supreme-court-judgments/) |
+| `indian-high-court-judgments` | 25 High Courts | [registry.opendata.aws](https://registry.opendata.aws/indian-high-court-judgments/) |
+
+Both buckets are:
+
+- hosted in the **`ap-south-1`** (Mumbai) region,
+- licensed **CC-BY-4.0**,
+- maintained by **Dattam Labs**.
+
+Judgment metadata lives in partitioned parquet files (queried with DuckDB);
+the PDFs are served as direct downloads (High Court) or per-year tar archives
+(Supreme Court). Both layers cache to disk under
+`~/.cache/bharat-courts/archive/`.
+
+!!! info "Update cadence: archive lags by 2–3 months"
+    - The Supreme Court bucket updates **bi-monthly**.
+    - The High Court buckets update **quarterly**.
+
+    A judgment delivered in the last 2–3 months may not be in the archive yet. If a
+    structured archive query returns nothing for a recent year, retry on the live
+    portal — for example `Judgments().find(..., source="live")`, or a direct
+    `JudgmentSearchClient` / `HCServicesClient` lookup.
+
+## Coverage at a glance
+
+| Court tier | Coverage | Available via |
+|---|---|---|
+| Supreme Court of India | Live recent-judgments feed; archive **1950 → present** | `SCIClient`, `ArchiveClient`, `Judgments` |
+| High Courts | **25 High Courts** (live case data + archive) | `HCServicesClient`, `JudgmentSearchClient`, `CalcuttaHCClient`, `ArchiveClient`, `Judgments` |
+| District Courts | **700+ court complexes** across 36 states/UTs (live only) | `DistrictCourtClient` |
+
+The full list of High Court codes is in the
+[Courts reference](../reference/courts.md).
+
+## Licensing
+
+### The bharat-courts software: MIT
+
+The bharat-courts library itself — the SDK, CLI, and the bundled AI-agent skill —
+is released under the **MIT License**. You are free to use it commercially, modify
+it, and redistribute it, subject to the MIT terms.
+
+### The data: terms of the originating source
+
+The *software* licence does not relicense the *data*. The data carries its own
+terms, which depend on where it came from:
+
+- **Archive data (both AWS Open Data buckets)** is licensed **CC-BY-4.0**.
+- **Live portal data** is retrieved directly from the official eCourts / court
+  websites and is subject to those portals' own terms of use.
+
+## Attribution
+
+When you redistribute or republish data obtained through bharat-courts, attribute
+the originating source — this is a condition of the CC-BY-4.0 licence on the
+archive, and good practice for the live portals.
+
+- **Archive (CC-BY-4.0):** attribute **Dattam Labs** (the bucket maintainers) and
+  the underlying **eCourts** platform. Retaining a link to the relevant AWS Open
+  Data registry page is the simplest way to satisfy the attribution requirement.
+- **Live portals:** credit the relevant **eCourts** portal or court website as the
+  source.
+
+!!! tip "Attributing in practice"
+    A short credit line is enough — for example: *"Judgment data via the Indian
+    High Court Judgments / Supreme Court Judgments AWS Open Data buckets
+    (CC-BY-4.0), maintained by Dattam Labs, sourced from the eCourts platform."*
+
+## Disclaimer
+
+!!! warning "Read this before relying on the data"
+    - **Not affiliated with the judiciary.** bharat-courts is an independent,
+      open-source tool. It is **not** affiliated with, endorsed by, or operated by
+      the Supreme Court of India, any High Court, any District Court, the eCourts
+      platform, or any government body.
+    - **Provided as-is, from public sources.** Data is surfaced as published by the
+      official portals and the public archive. bharat-courts does not alter the
+      substance of records; accuracy, completeness, and timeliness depend entirely
+      on the upstream source.
+    - **Verify mission-critical information against the official record.** For
+      anything that matters — limitation periods, hearing dates, the operative text
+      of an order or judgment — confirm against the official court record or a
+      certified copy before relying on it. The archive's freshness gap and the
+      occasional empty field on live results make independent verification
+      essential.
+    - **Not legal advice.** bharat-courts is a data-access tool. Nothing it returns,
+      and nothing in this documentation, constitutes legal advice.
+
+## See also
+
+- [How it works](how-it-works.md) — the architecture behind the live/archive split.
+- [Courts reference](../reference/courts.md) — every supported court and its codes.

--- a/docs/about/how-it-works.md
+++ b/docs/about/how-it-works.md
@@ -1,0 +1,223 @@
+# How it works
+
+bharat-courts gives you — and your AI assistant — programmatic access to Indian
+court data that otherwise lives behind clunky portals and hand-typed CAPTCHAs.
+Under the hood it is built from three pillars: a set of **live clients** that
+scrape the official eCourts portals, an **archive client** that queries a public
+historical dataset on AWS, and a **federated facade** that picks between them for
+you and returns one uniform result type.
+
+This page is a conceptual map of those pieces and how a query flows through them.
+It is semi-technical — useful if you want to understand the trade-offs, debug a
+result, or decide which entry point to reach for.
+
+## The big picture
+
+```text
+        your AI agent  /  your Python code  /  the CLI
+                              │
+                              ▼
+                  ┌───────────────────────┐
+                  │   Judgments  (facade)  │   routes by query shape
+                  └───────────┬───────────┘
+                  ┌───────────┴───────────┐
+                  ▼                       ▼
+        ┌──────────────────┐    ┌──────────────────────┐
+        │   Live clients   │    │   Archive client      │
+        │  (scrape portals)│    │  (DuckDB over AWS S3)  │
+        └────────┬─────────┘    └───────────┬──────────┘
+                 ▼                          ▼
+   hcservices / services /        s3://indian-supreme-court-judgments
+   judgments / sci.gov.in /       s3://indian-high-court-judgments
+   calcuttahighcourt.gov.in       (AWS Open Data, CC-BY-4.0)
+        OFFICIAL eCOURTS               PUBLIC ARCHIVE MIRROR
+```
+
+Everything resolves to **official sources**: either the live eCourts/Supreme
+Court portals, or the AWS Open Data buckets that mirror published judgments.
+bharat-courts never invents data — it fetches, parses, and normalises what those
+sources already publish.
+
+## Pillar 1 — Live clients (the official portals)
+
+The live clients scrape the same portals a lawyer would open in a browser. They
+answer questions about the **current** state of a matter: today's case status,
+the orders filed so far, tomorrow's cause list, the most recent Supreme Court
+judgments.
+
+| Client | Portal | Answers |
+|---|---|---|
+| `HCServicesClient` | hcservices.ecourts.gov.in | High Court case status, orders, cause lists |
+| `DistrictCourtClient` | services.ecourts.gov.in | 700+ district court complexes |
+| `JudgmentSearchClient` | judgments.ecourts.gov.in | Full-text judgment search + bulk PDF download |
+| `SCIClient` | www.sci.gov.in | Recent Supreme Court judgments feed |
+| `CalcuttaHCClient` | calcuttahighcourt.gov.in | Calcutta HC orders direct from the court website |
+
+Characteristics of the live path:
+
+- **CAPTCHA-gated.** Most search calls require solving an image CAPTCHA. The SDK
+  handles this automatically with a pluggable solver (OCR, ONNX, or your own) and
+  retries with a fresh session on failure. See the
+  [CAPTCHA guide](../guides/captcha.md).
+- **Rate-limited.** Requests go through a rate-limited HTTP client with retries
+  and browser-like headers, so you stay polite to the portals.
+- **Live and current.** This is the only way to see in-progress matters,
+  pending-case lists, and judgments delivered in the last few months.
+
+!!! note "Some live calls need no CAPTCHA"
+    Discovery calls — listing benches, case types, districts, or court
+    complexes — and the Supreme Court recent-judgments feed do not require a
+    CAPTCHA. Only the actual case/judgment searches do.
+
+### The HC Services portal protocol (high level)
+
+The High Court portal is session-bound, and the CAPTCHA is pinned to that
+session. At a high level, a search is a four-step dance the client performs for
+you:
+
+1. **Establish a session** — `GET main.php` sets the session cookie.
+2. **Fetch the CAPTCHA** — `GET securimage_show.php` returns the image, pinned to
+   that session.
+3. **Search** — `POST` the case query with the solved CAPTCHA; the portal returns
+   JSON.
+4. **Parse** — the client strips the response envelope and maps rows into clean
+   `CaseInfo` / `CaseOrder` objects.
+
+Because the CAPTCHA is pinned to the session, each retry needs a *fresh* session
+— which is exactly what the client does behind the scenes. You never write any of
+this yourself; you call `case_status(...)` and get back parsed results.
+
+## Pillar 2 — The archive client (AWS Open Data)
+
+The archive client (`ArchiveClient`, installed via the `[archive]` extra) reads
+two public AWS Open Data buckets maintained by Dattam Labs:
+
+- `s3://indian-supreme-court-judgments/` — the Supreme Court, **1950 to present**
+- `s3://indian-high-court-judgments/` — **25 High Courts**
+
+Both are CC-BY-4.0 licensed. Instead of scraping HTML, the archive runs SQL
+directly against partitioned **parquet** files using **DuckDB**, with anonymous
+(no-account) S3 access. PDFs are then pulled by direct HTTP GET (one file per High
+Court judgment) or random-access tar extraction (one tar per Supreme Court year).
+Both the metadata shards and the PDFs cache on disk under
+`~/.cache/bharat-courts/archive/`.
+
+Characteristics of the archive path:
+
+- **No CAPTCHA, no rate limits, no accounts.** It is plain object storage.
+- **Fast and partition-pruned.** Supplying a `year` and `court` lets DuckDB skip
+  straight to the relevant shards, so even large queries stay quick.
+- **Historical, with a freshness gap.** The buckets refresh bi-monthly (Supreme
+  Court) and quarterly (High Courts), so they lag real-world filings by roughly
+  2–3 months. For anything decided in the last couple of months, use the live
+  path instead.
+
+This is the right backend for research workloads — "every judgment by Justice X",
+"all 2020 Delhi writ petitions", bulk PDF retrieval. See the
+[archive guide](../guides/archive.md) and the
+[data sources page](data-sources.md) for the full picture.
+
+## Pillar 3 — The `Judgments` facade (routing for you)
+
+Most of the time you want *a judgment matching some criteria* and do not care
+whether it came from a live portal or the archive. The `Judgments` facade is the
+recommended default. It owns both backends — lazily, so you only pay for what you
+install — exposes a single `find(...)` method, and returns a uniform
+`list[Judgment]` regardless of source. Each returned `Judgment` carries a
+`source` field (`"archive"` or `"live"`) so you can still tell where it came from.
+
+### How it routes
+
+The facade inspects the *shape* of your query and picks a backend. With the
+default `source="auto"`:
+
+| Filter shape | Backend chosen | Why |
+|---|---|---|
+| `cnr=` set | archive | the CNR prefix resolves directly to a court partition — no scan |
+| `text=` only | live | only the live judgments portal does full-body text search |
+| structured only (`court`/`year`/`judge`/`party`/`citation`) | archive | faster, no CAPTCHA |
+| `text=` + structured | archive | `text` folds into a title-substring match |
+| nothing | — | raises `ValueError` |
+
+You can always override with `source="archive"` or `source="live"`.
+
+Every routing decision is logged at INFO under the `bharat_courts.facade`
+logger, so the choice is debuggable in production.
+
+!!! info "Mixed text + structured stays on the archive"
+    When you combine `text=` with structured filters, the facade routes to the
+    archive and folds your `text` into a title/party substring match. The archive
+    cannot do full-body search — but it is far faster than burning a CAPTCHA on
+    the live portal, and the behaviour is predictable.
+
+!!! warning "Live PDF fetch is not handled by the facade"
+    `Judgments.fetch_pdf()` works for archive judgments and for CNR strings whose
+    prefix maps to an archive-supported court. Passing a `Judgment` with
+    `source="live"` raises `NotImplementedError`: the live download needs the
+    original `JudgmentResult` (for the CAPTCHA-validated session). For those, call
+    `JudgmentSearchClient.download_pdf(...)` directly.
+
+A minimal end-to-end example:
+
+```python
+import asyncio
+from bharat_courts import Judgments
+
+async def main():
+    async with Judgments() as j:
+        # Structured → archive (no CAPTCHA, partition-pruned)
+        for r in await j.find(judge="chandrachud", year=(2018, 2024),
+                              court="sci", limit=10):
+            print(r.decision_date, r.case_id, r.title, f"[{r.source}]")
+
+        # Free-text → live (only it does full-body search)
+        for r in await j.find(text="right to privacy", limit=5):
+            print(r.title, f"[{r.source}]")
+
+        # CNR alone → archive, prefix-routed, no scan
+        result = await j.find(cnr="DLHC010230802020")
+        pdf = await j.fetch_pdf(result[0])
+
+asyncio.run(main())
+```
+
+See the [facade guide](../guides/facade.md) for the full method reference.
+
+## CNR-prefix routing
+
+Every Indian case has a 16-character **CNR** (Case Number Record) number, and its
+first four letters identify the court. bharat-courts uses this to route a CNR
+straight to the correct source without scanning every bucket.
+
+The helper is `infer_court_from_cnr(cnr)`:
+
+```python
+from bharat_courts import infer_court_from_cnr
+
+infer_court_from_cnr("DLHC010230802020")  # → Delhi High Court
+infer_court_from_cnr("ESCR010000301950")  # → Supreme Court of India
+infer_court_from_cnr("ZZZZ012345")        # → None
+```
+
+It is verified against all 25 High Court partitions plus the Supreme Court. Both
+`ArchiveClient.search(cnr=...)` and the `Judgments` facade apply it automatically
+for CNR-only queries — so a `fetch_pdf("DLHC...")` knows it needs the High Court
+bucket without you naming the court.
+
+??? note "A few prefixes are not the obvious abbreviation"
+    Most CNR prefixes follow a `<state>HC…` pattern, but a handful do not —
+    Bombay uses `HCBM`, Madras `HCMA`, Telangana `HBHC`, and Calcutta `WBCH`.
+    The full mapping is baked into the court registry, so you never have to
+    memorise these.
+
+## Where the data comes from
+
+To keep the chain of trust clear:
+
+- **Live results** are scraped from the official eCourts and Supreme Court
+  portals at the moment you ask. They reflect the current state of the matter.
+- **Archive results** come from the AWS Open Data buckets — a published mirror of
+  decided judgments, refreshed periodically and licensed CC-BY-4.0.
+
+Neither path adds editorial content. For more on the buckets, update cadence, and
+attribution requirements, see [Data sources](data-sources.md).

--- a/docs/assets/favicon.svg
+++ b/docs/assets/favicon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" fill="none">
+  <defs>
+    <linearGradient id="bcf" x1="0" y1="0" x2="32" y2="32" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#7c7cf0"/><stop offset="1" stop-color="#5b5bd6"/>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="8" fill="url(#bcf)"/>
+  <g stroke="#fff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <path d="M16 8v16"/>
+    <path d="M9 11.5h14"/>
+    <path d="M9 11.5 6.5 16.5h5z"/>
+    <path d="M23 11.5 20.5 16.5h5z"/>
+    <path d="M12 24h8"/>
+  </g>
+</svg>

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" fill="none">
+  <defs>
+    <linearGradient id="bc" x1="0" y1="0" x2="32" y2="32" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#7c7cf0"/><stop offset="1" stop-color="#5b5bd6"/>
+    </linearGradient>
+  </defs>
+  <rect x="2" y="2" width="28" height="28" rx="8" fill="url(#bc)"/>
+  <!-- balance / scales of justice, simplified -->
+  <g stroke="#fff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <path d="M16 8.5v15"/>
+    <path d="M9.5 11.5h13"/>
+    <path d="M9.5 11.5 7 16.5h5z"/>
+    <path d="M22.5 11.5 20 16.5h5z"/>
+    <path d="M12.5 23.5h7"/>
+  </g>
+  <circle cx="16" cy="8.5" r="1.4" fill="#fff"/>
+</svg>

--- a/docs/guides/archive.md
+++ b/docs/guides/archive.md
@@ -1,0 +1,220 @@
+# Historical Archive (`ArchiveClient`)
+
+`ArchiveClient` reads two **public AWS Open Data** S3 buckets directly with
+DuckDB. It is the engine behind every historical and bulk query in
+bharat-courts: no CAPTCHA, no rate limits, and no AWS account required.
+
+Reach for the archive when the user wants **historical research**, **bulk PDF
+retrieval**, or a judgment with a **known CNR**. For *current* state — case
+status, next hearing, cause lists, orders just uploaded — use the live clients
+instead (see [High Courts](high-courts.md) and
+[Judgment Search](judgment-search.md)).
+
+!!! info "Where this sits"
+    Most callers should start with the [`Judgments` facade](facade.md), which
+    calls `ArchiveClient` for you and routes archive-vs-live by query shape.
+    Drop down to `ArchiveClient` directly only for archive-specific operations
+    the facade does not expose — chiefly `iter_judgments` (bulk streaming) and
+    `prefetch_sci_year` (pre-warming the cache).
+
+## The data
+
+| Bucket | Coverage | Update cadence |
+|---|---|---|
+| `s3://indian-supreme-court-judgments/` | Supreme Court of India, **1950 → present** | bi-monthly |
+| `s3://indian-high-court-judgments/` | **25 High Courts** | quarterly |
+
+Both buckets live in `ap-south-1`, are licensed **CC-BY-4.0**, and are
+maintained by **Dattam Labs**. Because the data is public, anonymous S3 access
+is used — you do not need credentials.
+
+See [Data sources](../about/data-sources.md) for the full provenance and
+attribution details.
+
+## Installation
+
+The archive is an opt-in extra (it pulls in DuckDB):
+
+```bash
+pip install "bharat-courts[archive]"
+```
+
+## Quick start
+
+```python
+import asyncio
+from bharat_courts import ArchiveClient
+
+async def main():
+    async with ArchiveClient() as client:
+        # Search by judge + year range (partition-pruned in DuckDB)
+        results = await client.search(
+            court="sci", judge="chandrachud", year=(2018, 2024), limit=20,
+        )
+        for j in results:
+            print(f"{j.decision_date}  {j.case_id}  {j.title}")
+            print(f"  {j.citation}  outcome: {j.disposal_nature}")
+
+asyncio.run(main())
+```
+
+Every row comes back as a unified [`Judgment`](../reference/models.md) with
+`.source = "archive"`, so it interoperates with results from the live clients
+and the facade.
+
+## Method reference
+
+| Method | Returns | Description |
+|---|---|---|
+| `search(*, court=None, year=None, judge=None, party=None, citation=None, cnr=None, limit=50)` | `list[Judgment]` | One-shot search across both buckets (or just one if `court` is given). CNR-only queries auto-route via the prefix. |
+| `iter_judgments(*, court=None, year=None, judge=None, party=None, citation=None, cnr=None, batch_size=500, max_results=None)` | `AsyncIterator[Judgment]` | Stream pages via `LIMIT`/`OFFSET` with a stable sort. Use for more than ~50 rows. |
+| `fetch_pdf(judgment_or_cnr, *, language="english")` | `bytes` | PDF bytes. Pass a `Judgment` to skip the lookup, or a CNR string. SCI supports regional languages. |
+| `prefetch_sci_year(year, language="english")` | `str` (local path) | Pre-warm a SCI year tar before a batch of fetches. |
+| `count(*, court=None, year=None)` | `dict[str, int]` | Per-bucket row counts. |
+| `cache_info()` | `dict` | `cache_dir`, `files`, `bytes`, `max_bytes`. |
+
+### Shared filter arguments
+
+`search`, `iter_judgments`, and `count` share the same filter vocabulary:
+
+| Argument | Type | Notes |
+|---|---|---|
+| `court` | `Court \| str \| None` | A `Court`, a code (`"sci"`, `"delhi"`), or `None` to query **both** SCI and all 25 HCs. |
+| `year` | `int \| tuple[int, int] \| None` | Single year (`2020`) or inclusive range (`(2018, 2024)`). Strongly recommended — drives partition pruning. (`count` takes a single `int` only.) |
+| `judge` | `str` | Case-insensitive substring match. |
+| `party` | `str` | SCI: matches petitioner, respondent, and title. HC: title only (see warning below). |
+| `citation` | `str` | SCI only — silently ignored for HC. |
+| `cnr` | `str` | Exact match. When `court` is omitted, the 4-letter prefix infers the court automatically. |
+
+## Worked examples
+
+### Judge + year-range search
+
+```python
+async with ArchiveClient() as client:
+    results = await client.search(
+        court="delhi", judge="hari shankar", year=(2019, 2021), limit=25,
+    )
+    for j in results:
+        print(j.decision_date, j.case_id, j.title)
+```
+
+### CNR lookup (court auto-inferred)
+
+You do not need to pass `court` when you have a CNR — the first four letters of
+the CNR identify the bucket and partition, so the lookup is instant and avoids
+scanning all 25 HC partitions.
+
+```python
+async with ArchiveClient() as client:
+    results = await client.search(cnr="DLHC010230802020")   # → Delhi HC
+    sci = await client.search(cnr="ESCR010000301950")       # → Supreme Court
+```
+
+!!! tip "Inspect the routing yourself"
+    `bharat_courts.infer_court_from_cnr(cnr)` returns the resolved `Court`
+    (or `None`, never raising) so you can see exactly where a CNR will route.
+    Note the legacy prefixes: Bombay = `HCBM`, Madras = `HCMA`,
+    Telangana = `HBHC`, Calcutta = `WBCH`.
+
+### Bulk streaming with `iter_judgments`
+
+For large pulls — "every Delhi 2020 judgment" is roughly 18,000 rows — stream
+instead of using a huge `limit`. Pages are fetched via `LIMIT`/`OFFSET`, so you
+start consuming results immediately and never hold the full set in memory.
+
+```python
+async with ArchiveClient() as client:
+    count = 0
+    async for j in client.iter_judgments(court="delhi", year=2020, batch_size=500):
+        count += 1
+        # process(j) — write to a file, index, etc.
+    print(f"Streamed {count} judgments")
+```
+
+Sources stream sequentially (SCI first, then HC) and each source is internally
+sorted by `decision_date DESC, cnr`, so individual pages are deterministic.
+There is **no** cross-source date merge across SCI and HC in streaming mode.
+Use `max_results=N` to cap the total yielded across sources.
+
+### Fetch a PDF to disk
+
+`fetch_pdf` accepts either a `Judgment` (preferred — no extra lookup) or a CNR
+string (which triggers one metadata query first).
+
+```python
+async with ArchiveClient() as client:
+    pdf_bytes = await client.fetch_pdf("DLHC010230802020")
+    with open("judgment.pdf", "wb") as f:
+        f.write(pdf_bytes)
+```
+
+### Regional-language SCI PDF
+
+The Supreme Court archive carries regional-language renderings. The `language`
+argument is only meaningful for SCI — HC PDFs in the archive are English-only.
+
+```python
+async with ArchiveClient() as client:
+    hindi = await client.fetch_pdf("ESCR010000301950", language="hindi")
+    # other values: "tamil", "gujarati", … (see SCI_LANGUAGE_MAP)
+```
+
+### Pre-warm a year before a batch
+
+If you are about to fetch many SCI PDFs from the same year, warm the tar once
+so the per-PDF fetches are cheap:
+
+```python
+async with ArchiveClient() as client:
+    local_tar = await client.prefetch_sci_year(2020)
+    print("warmed:", local_tar)
+    # subsequent fetch_pdf(...) calls for 2020 read from this tar
+```
+
+### Sizing a query with `count`
+
+```python
+async with ArchiveClient() as client:
+    print(await client.count(court="delhi", year=2020))  # {"hc": 18000}
+    print(await client.count(year=2020))                 # {"sci": ..., "hc": ...}
+```
+
+## Gotchas
+
+!!! warning "Freshness lag"
+    The archive is **not** real-time. SCI updates bi-monthly and HC updates
+    quarterly, so anything decided in the last 2–3 months may not be present.
+    If a structured query returns nothing for a recent year, fall back to the
+    live `JudgmentSearchClient` / `HCServicesClient` (or call the facade with
+    `source="live"`), and tell the user about the gap.
+
+!!! warning "No party or citation search on High Courts"
+    The HC parquet has no separate `petitioner`/`respondent` columns and no
+    `citation` column. As a result `party=` matches against the **title only**
+    for HC, and `citation=` is **silently ignored** for HC. SCI supports both
+    as expected.
+
+!!! warning "First SCI fetch downloads a large tar"
+    SCI PDFs are packaged one tar per year (~40–500 MB). The first
+    `fetch_pdf` for a given SCI year downloads that whole tar; subsequent
+    fetches in the same year are essentially free (random-access from the
+    cached tar). Warn the user before kicking off SCI fetches spanning many
+    years. HC PDFs, by contrast, are fetched per-file (~250 KB each).
+
+!!! note "On-disk PDF cache and the size cap"
+    PDFs and tars cache under `~/.cache/bharat-courts/archive/` with a **5 GiB**
+    default cap and LRU eviction. Override the cap with the
+    `BHARAT_COURTS_ARCHIVE_CACHE_MAX_GB` environment variable. Inspect the cache
+    at any time with `cache_info()`, which returns `cache_dir`, `files`,
+    `bytes`, and `max_bytes`.
+
+!!! note "Attribution (CC-BY-4.0)"
+    When you redistribute archive data or PDFs, attribute **Dattam Labs /
+    eCourts** per the CC-BY-4.0 licence.
+
+## See also
+
+- [API reference: `ArchiveClient`](../reference/archive.md) — full signatures and types.
+- [The `Judgments` facade](facade.md) — the recommended default that routes between archive and live for you.
+- [Data sources](../about/data-sources.md) — bucket provenance, licence, and update cadence.

--- a/docs/guides/calcutta-hc.md
+++ b/docs/guides/calcutta-hc.md
@@ -1,0 +1,177 @@
+# Calcutta High Court (Direct Client)
+
+`CalcuttaHCClient` talks **directly** to the official Calcutta High Court website
+(`calcuttahighcourt.gov.in`) instead of going through the national eCourts portal.
+
+Why a dedicated client? For Calcutta High Court matters, the court's own site has
+**better PDF coverage** than the eCourts judgment portal — orders and judgments from
+**September 2020 onwards** (the period covered by the court's CIS system) are reliably
+available here, often when the eCourts copy is missing. If you practise before the
+Calcutta High Court, this is usually the client you want.
+
+!!! info "What this client does"
+    Search a case by its case-type / number / year, get back the case metadata and the
+    list of orders passed in it, then download any order PDF. It is CAPTCHA-gated (solved
+    automatically when you have `bharat-courts[ocr]` installed) and rate-limited, like the
+    other live clients.
+
+## When to use it
+
+| You want… | Use |
+|---|---|
+| Orders / judgment PDFs in a specific Calcutta HC case (Sept 2020 onward) | **`CalcuttaHCClient.search_orders`** |
+| A judgment by judge / year / citation across all courts (historical) | [`Judgments().find(...)`](facade.md) (archive) |
+| Full-text keyword search of HC judgments | [`JudgmentSearchClient`](judgment-search.md) |
+| Live case status / next hearing for any HC | [`HCServicesClient`](high-courts.md) |
+
+## Quick start
+
+This example searches **WPA 12886 of 2024** on the Appellate Side and downloads the PDF
+of every order that has one.
+
+```python
+import asyncio
+from bharat_courts import CalcuttaHCClient
+
+
+async def main():
+    async with CalcuttaHCClient() as client:
+        case_info, orders = await client.search_orders(
+            case_type="12",        # numeric case-type code; "12" = WPA
+            case_number="12886",
+            year="2024",
+            establishment="appellate",
+        )
+
+        if case_info:
+            print(f"{case_info.case_number}: "
+                  f"{case_info.petitioner} vs {case_info.respondent}")
+            print(f"CNR: {case_info.cnr_number}  ({case_info.court_name})")
+
+        for i, order in enumerate(orders):
+            print(f"{order.order_date} | {order.order_type} | "
+                  f"{order.judge} | {order.neutral_citation}")
+            if order.pdf_url:
+                pdf = await client.download_order_pdf(order.pdf_url)
+                with open(f"wpa_12886_2024_order_{i}.pdf", "wb") as f:
+                    f.write(pdf)
+                print(f"  saved {len(pdf)} bytes")
+
+
+asyncio.run(main())
+```
+
+!!! tip "No solver to configure"
+    With `pip install bharat-courts[ocr]`, the client auto-detects the OCR CAPTCHA solver
+    and retries on its own — you don't pass anything. See the
+    [CAPTCHA guide](captcha.md) for manual, ONNX, or custom solvers.
+
+## `search_orders`
+
+```python
+async def search_orders(
+    self,
+    *,
+    case_type: str,
+    case_number: str,
+    year: str,
+    establishment: str = "appellate",
+    max_captcha_attempts: int = 5,
+) -> tuple[CaseInfo | None, list[CaseOrder]]
+```
+
+Searches a single case and returns its metadata plus its orders.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `case_type` | `str` | required | Numeric case-type code (e.g. `"12"` for WPA). |
+| `case_number` | `str` | required | Case registration number, e.g. `"12886"`. |
+| `year` | `str` | required | Case year, e.g. `"2024"`. |
+| `establishment` | `str` | `"appellate"` | Which bench/side — see table below. |
+| `max_captcha_attempts` | `int` | `5` | CAPTCHA solve retries; each retry opens a fresh session. |
+
+**Returns** a tuple `(CaseInfo | None, list[CaseOrder])`:
+
+- The first element carries case-level metadata (CNR, parties, full case number, court
+  name). It is `None` when nothing matched and no metadata could be recovered.
+- The second element is the list of orders. It can be empty even when `CaseInfo` is
+  present (a case exists but has no published orders yet).
+
+!!! note "Always unpack the tuple"
+    `search_orders` returns **two** values. Write
+    `case_info, orders = await client.search_orders(...)` — not a single list.
+
+### `establishment` values
+
+The Calcutta High Court is split across four establishments. Pass the lowercase name:
+
+| Value | Bench / side |
+|---|---|
+| `"appellate"` | Appellate Side (default) |
+| `"original"` | Original Side |
+| `"jalpaiguri"` | Circuit Bench at Jalpaiguri |
+| `"portblair"` | Circuit Bench at Port Blair |
+
+### About CAPTCHA retries
+
+Each retry opens a brand-new session before fetching a fresh CAPTCHA image, because the
+CAPTCHA is pinned to the server session. A wrong CAPTCHA comes back as an HTTP 422, which
+the client treats as "retry"; genuine validation errors propagate. The default of 5
+attempts keeps the all-fail rate negligible with OCR solving, at roughly 3–4 seconds of
+overhead per retry.
+
+## `download_order_pdf`
+
+```python
+async def download_order_pdf(self, pdf_url: str) -> bytes
+```
+
+Downloads an order/judgment PDF given the `pdf_url` from a `CaseOrder`. The download
+itself needs no CAPTCHA. Returns raw PDF bytes.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `pdf_url` | `str` | The URL from `CaseOrder.pdf_url`. |
+
+!!! warning "Validity check"
+    If the server returns an error string instead of a real PDF, this method raises
+    `RuntimeError` rather than writing junk to disk — it checks for the `%PDF` magic bytes
+    at the head of the response. Guard your calls with `if order.pdf_url:` since not every
+    order row has a resolvable PDF.
+
+## What you get back: `CaseOrder`
+
+Each order in the returned list is a `CaseOrder`. The fields most relevant here:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `order_date` | `date` | Date the order was passed. |
+| `order_type` | `str` | `"Judgment"`, `"Order"`, or `"Interim Order"`. |
+| `judge` | `str` | Judge(s) who passed the order. |
+| `neutral_citation` | `str` | Neutral citation, when the court has assigned one. |
+| `pdf_url` | `str` | URL to download the order PDF (may be empty). |
+| `order_text` | `str` | Order text, when available. |
+| `pdf_bytes` | `bytes \| None` | Populated only if you store the download yourself. |
+
+The accompanying `CaseInfo` exposes `case_number`, `case_type`, `cnr_number`,
+`petitioner`, `respondent`, and `court_name` (the court's own `side` label, e.g.
+"Calcutta High Court - Appellate Side"). See the
+[clients API reference](../reference/clients.md) for the complete signatures and the full
+model definitions.
+
+## Notes and limitations
+
+- **Coverage starts September 2020.** Older matters predate the CIS system and are not
+  available through this client. For historical Calcutta judgments, try the
+  [archive via the facade](facade.md) (the Calcutta HC partition is included).
+- **Case-type codes are numeric and court-specific.** `"12"` is WPA; you'll need the
+  correct numeric code for other case types.
+- **Rate limiting is built in** (about one second between requests by default) — see
+  [configuration](../start/configuration.md) to tune it.
+
+## See also
+
+- [Live High Courts (eCourts) →](high-courts.md)
+- [Judgment search (full-text) →](judgment-search.md)
+- [The `Judgments` facade →](facade.md)
+- [Clients API reference →](../reference/clients.md)

--- a/docs/guides/captcha.md
+++ b/docs/guides/captcha.md
@@ -1,0 +1,227 @@
+# CAPTCHA Solving
+
+The live eCourts portals — **HC Services**, **District Courts**, the **judgments**
+portal, and **Calcutta High Court** — gate every search behind a
+[Securimage](https://www.phpcaptcha.org/) CAPTCHA: a distorted six-character
+alphanumeric image you normally have to read and type by hand.
+
+bharat-courts makes this pluggable. Every live client accepts a `captcha_solver`,
+and the SDK ships several ready-made solvers plus a tiny interface for writing your
+own. In most cases you do nothing: install the recommended extra and the client
+picks the best available solver for you.
+
+!!! info "The archive needs no CAPTCHA"
+    Only the *live* clients are CAPTCHA-gated. The historical
+    [archive](archive.md) (AWS Open Data) and the `Judgments` facade's archive
+    route are CAPTCHA-free, rate-limit-free, and need no solver at all. If your
+    query can be answered from the archive, you avoid this whole topic.
+
+## The `CaptchaSolver` interface
+
+All solvers subclass a single abstract base class, `CaptchaSolver`, with one
+async method:
+
+```python
+from abc import ABC, abstractmethod
+
+
+class CaptchaSolver(ABC):
+    @abstractmethod
+    async def solve(self, image_bytes: bytes) -> str:
+        """Given raw CAPTCHA image bytes, return the solved text."""
+        ...
+```
+
+The client fetches the CAPTCHA image, hands the raw bytes to `solve()`, and uses
+the returned string. That is the entire contract — anything that can turn image
+bytes into a string can be a solver.
+
+## The four built-in options
+
+| Solver | Extra | Auth needed | Notes |
+|---|---|---|---|
+| `OCRCaptchaSolver` | `[ocr]` | None | **Recommended default.** ddddocr deep-learning recognition. |
+| `ONNXCaptchaSolver` | `[onnx]` | `HF_TOKEN` | Lighter (onnxruntime); model downloaded from HuggingFace. |
+| `ManualCaptchaSolver` | (bundled) | None | Prompts a human on stdin or via a callback. |
+| Custom subclass | — | — | Bring your own model or paid solving service. |
+
+### Auto-detection — you usually pass nothing
+
+The live clients auto-detect the best available solver. If you installed
+`bharat-courts[ocr]`, the default solver is `OCRCaptchaSolver` and you can omit
+`captcha_solver` entirely:
+
+```python
+import asyncio
+from bharat_courts import get_court, HCServicesClient
+
+
+async def main():
+    court = get_court("delhi")
+    # No captcha_solver= passed — the client uses OCRCaptchaSolver automatically.
+    async with HCServicesClient() as client:
+        cases = await client.case_status(
+            court, case_type="134", case_number="1", year="2024"
+        )
+        for c in cases:
+            print(c.case_number, c.petitioner, "vs", c.respondent)
+
+
+asyncio.run(main())
+```
+
+Pass an explicit `captcha_solver=` only when you want a different solver than the
+auto-detected one (for example, forcing manual entry, or wiring in your own).
+
+## Option 1 — `OCRCaptchaSolver` (recommended)
+
+The default. Uses [ddddocr](https://github.com/sml2h3/ddddocr), a deep-learning
+CAPTCHA recogniser that handles Securimage images well out of the box. No
+authentication, no token, no external service.
+
+```bash
+pip install bharat-courts[ocr]
+```
+
+```python
+from bharat_courts.captcha.ocr import OCRCaptchaSolver
+
+solver = OCRCaptchaSolver()
+```
+
+Constructor options:
+
+| Parameter | Default | Meaning |
+|---|---|---|
+| `preprocess` | `False` | Apply Pillow binarisation + median-filter cleanup before OCR. |
+| `threshold` | `128` | Binarisation threshold (0–255), used only when `preprocess=True`. |
+
+OCR is not perfect — a single decode lands somewhere around 60% of the time — but
+this is by design. The solver validates its own output: if the decode isn't
+exactly six alphanumeric characters, it returns an empty string instead of
+guessing. The eCourts portals reject the wrong length anyway, so the empty string
+signals the client to retry rather than waste a submission.
+
+!!! tip "Retries are automatic"
+    You don't loop manually. The live clients retry on a failed or rejected
+    CAPTCHA up to a per-method `max_captcha_attempts` (default `3`), and because
+    the CAPTCHA is pinned to the PHP session, the library spins up a **fresh
+    session** for each retry so it gets a brand-new image. A few automatic
+    retries usually clear a ~60%-per-attempt solver.
+
+## Option 2 — `ONNXCaptchaSolver`
+
+A lighter alternative that runs a pre-trained ONNX model on `onnxruntime` + Pillow
+instead of pulling in ddddocr. Same six-character validation and retry behaviour
+as the OCR solver.
+
+```bash
+pip install bharat-courts[onnx]
+```
+
+```python
+import os
+from bharat_courts.captcha.onnx import ONNXCaptchaSolver
+
+os.environ["HF_TOKEN"] = "hf_..."  # or export it in your shell beforehand
+solver = ONNXCaptchaSolver()
+```
+
+The model (`captchabreaker`) is downloaded from HuggingFace on first use and
+cached at `~/.cache/bharat-courts/`. The constructor downloads eagerly so any
+authentication error surfaces immediately rather than mid-search.
+
+!!! warning "ONNXCaptchaSolver requires `HF_TOKEN`"
+    The ONNX model is hosted on HuggingFace, which requires authentication to
+    download. Set the `HF_TOKEN` environment variable before constructing the
+    solver:
+
+    ```bash
+    export HF_TOKEN=hf_...
+    ```
+
+    Get a token at <https://huggingface.co/settings/tokens>. Without it, the
+    solver raises a `RuntimeError` (HTTP 401) on construction. If you don't have
+    a token, prefer `OCRCaptchaSolver`, which needs no authentication.
+
+You can also point it at a local model file to skip the download entirely:
+
+```python
+solver = ONNXCaptchaSolver(model_path="/path/to/model.onnx")
+```
+
+## Option 3 — `ManualCaptchaSolver`
+
+For interactive sessions or debugging, let a human read the CAPTCHA. By default
+it writes the image to a temp file, prints the path to stderr, and waits for you
+to type the text on stdin.
+
+```python
+from bharat_courts.captcha.manual import ManualCaptchaSolver
+
+solver = ManualCaptchaSolver()  # saves image to a temp PNG, prompts on stdin
+```
+
+For GUI or web workflows, pass a callback that receives the image bytes and
+returns (or awaits) the solved text — for example, to display the image in your
+own UI and collect the answer:
+
+```python
+def my_callback(image_bytes: bytes) -> str:
+    # show image_bytes to the user, collect their answer
+    return show_in_ui_and_wait(image_bytes)
+
+
+solver = ManualCaptchaSolver(callback=my_callback)
+```
+
+The callback may be sync or async — both are supported.
+
+## Option 4 — Write your own solver
+
+Anything that turns image bytes into a string can be a solver. Subclass
+`CaptchaSolver` and implement the single async `solve` method. This is the hook
+for a paid CAPTCHA-solving service, a model you host yourself, or a queue you push
+images onto.
+
+```python
+from bharat_courts.captcha.base import CaptchaSolver
+
+
+class MyServiceSolver(CaptchaSolver):
+    def __init__(self, api_key: str):
+        self._api_key = api_key
+
+    async def solve(self, image_bytes: bytes) -> str:
+        # call your service, return the six-character text
+        return await my_service.recognise(image_bytes, key=self._api_key)
+
+
+# Use it like any built-in solver:
+from bharat_courts import HCServicesClient
+
+async with HCServicesClient(captcha_solver=MyServiceSolver(api_key="...")) as client:
+    ...
+```
+
+!!! note "Validate your own output"
+    The built-in solvers return an empty string when the decode isn't a valid
+    six-character alphanumeric, which the client treats as "retry with a fresh
+    image." If you write your own solver, returning `""` on low-confidence
+    output gives you the same free retry instead of burning an attempt on a bad
+    guess.
+
+## Why retries use fresh sessions
+
+The CAPTCHA is **pinned to the PHP session** on the eCourts side: the image you
+were shown is only valid for the cookie you were issued. You can't simply ask for
+a new image on the same session and re-submit. The live clients handle this for
+you — each retry creates a fresh session (new cookie, new CAPTCHA image) before
+calling your solver again. You never manage this manually; it's why a ~60% solver
+still gets you through within the default three attempts.
+
+## See also
+
+- [Installation](../start/installation.md) — the `[ocr]`, `[onnx]`, and `[all]` extras.
+- [CAPTCHA reference](../reference/captcha.md) — full API for the solver classes.
+- [High Courts guide](high-courts.md) and [District Courts guide](district-courts.md) — the CAPTCHA-gated live clients in context.

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -1,0 +1,354 @@
+# Command-line interface
+
+Everything the SDK can do is also available from your terminal via the
+`bharat-courts` command. The CLI is a thin wrapper over the same async clients —
+no scripting required for one-off lookups, ad-hoc research, or shell pipelines.
+
+The command tree maps one-to-one onto the SDK modules:
+
+```text
+bharat-courts version
+bharat-courts courts [--type all|hc|sc]
+bharat-courts install-skills
+bharat-courts find ...               # the CLI twin of the Judgments facade
+
+bharat-courts hcservices ...         # hcservices.ecourts.gov.in
+bharat-courts districtcourts ...     # services.ecourts.gov.in
+bharat-courts calcuttahc ...         # calcuttahighcourt.gov.in
+bharat-courts judgments ...          # judgments.ecourts.gov.in
+bharat-courts sci ...                # www.sci.gov.in
+bharat-courts archive ...            # AWS Open Data archive
+```
+
+!!! info "Install the CLI extra"
+
+    The CLI ships behind its own optional dependency. Install it (and, for the
+    `archive` commands, the archive extra) with:
+
+    ```bash
+    pip install 'bharat-courts[cli]'
+    pip install 'bharat-courts[cli,archive,ocr]'   # everything you'll want for daily use
+    ```
+
+    See [Installation](../start/installation.md) for the full matrix of extras.
+
+## Global flags
+
+These flags work on **every** subcommand and must come *before* the command
+name (they belong to the root `bharat-courts` group):
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--json` | off | Emit machine-readable JSON instead of human-readable text. |
+| `--captcha-attempts N` | `5` | Max CAPTCHA solve attempts per call. Applies to the `judgments` and `calcuttahc` groups; `hcservices`/`districtcourts` use a fixed internal budget. |
+| `-v`, `--verbose` | off | Turn on INFO-level SDK logging (routing decisions, retries) on stderr. |
+| `--version` | — | Print the version and exit. |
+| `--help` | — | Show help for any command or group. |
+
+```bash
+bharat-courts --json find --judge chandrachud --year 2018-2024 --court sci
+bharat-courts --verbose hcservices benches delhi
+bharat-courts --version
+```
+
+!!! tip "`--json` is built for pipelines"
+
+    With `--json`, the CLI prints a single, indented JSON document and nothing
+    else — no banners, no progress chatter. That makes it safe to pipe straight
+    into `jq`, write to a file, or load into another tool:
+
+    ```bash
+    bharat-courts --json find --court delhi --year 2020 --limit 100 \
+      | jq '.[] | {date: .decision_date, title}'
+
+    bharat-courts --json archive count --court sci > sci_counts.json
+    ```
+
+    Every model serialises via `to_dict(exclude_none=True)`, so dates come back
+    as ISO strings and empty fields are dropped.
+
+## Top-level commands
+
+### `find` — the federated search command
+
+`bharat-courts find` is the command-line twin of the [`Judgments`
+facade](facade.md). You describe the data you want; it picks the archive or the
+live portal for you and prints a uniform list of judgments.
+
+| Option | Description |
+|--------|-------------|
+| `--text` | Free-text keyword search. On its own, routes to the **live** portal (only it does full-body search). |
+| `--court` | Court code: `sci`, `delhi`, `bombay`, etc. |
+| `--year` | Single year (`2020`) or an inclusive range (`2018-2024`). |
+| `--judge` | Substring on the judge name (archive). |
+| `--party` | Substring on petitioner/respondent (SCI) or title (HC). |
+| `--citation` | SCI citation substring. |
+| `--cnr` | A CNR — auto-routes to the archive via its 4-letter prefix. |
+| `--source` | `auto` (default), `archive`, or `live` — override the automatic routing. |
+| `--limit` | Max results to return (default `20`). |
+
+The routing in `auto` mode mirrors the facade exactly:
+
+| Filters supplied | Backend chosen |
+|------------------|----------------|
+| `--cnr` | archive (prefix → court → partition) |
+| `--text` only | live |
+| structured only (court/year/judge/party/citation) | archive |
+| `--text` + structured | archive (text folds into a title-match) |
+| nothing | error |
+
+```bash
+# Structured filters → archive, no CAPTCHA
+bharat-courts find --judge chandrachud --year 2018-2024 --court sci --limit 10
+
+# Free text → live full-body search (needs a CAPTCHA solver installed)
+bharat-courts find --text "right to privacy" --limit 5
+
+# CNR alone → archive, prefix-routed
+bharat-courts find --cnr DLHC010230802020
+```
+
+Human output:
+
+```text
+Found 3 judgment(s):
+
+[archive] Justice K.S. Puttaswamy (Retd.) vs Union Of India
+  CNR ... · Civil Appeal No. ... · (2017) 10 SCC 1
+  Court: Supreme Court of India
+  Decided: 2017-08-24
+  Bench: D.Y. Chandrachud, ...
+  Outcome: Allowed
+```
+
+The same call with `--json` returns a JSON array of `Judgment` objects, each
+carrying a `source` field (`"archive"` or `"live"`) so you can tell where every
+row came from.
+
+### `courts` — list the court registry
+
+```bash
+bharat-courts courts                 # all 30 courts
+bharat-courts courts --type hc       # High Courts only
+bharat-courts courts --type sc       # Supreme Court only
+```
+
+`--type` accepts `all` (default), `hc`, or `sc`. Human output is a table of
+**Code / Name / State Code / Type**; `--json` returns the same as an array of
+`Court` dicts. Use the **Code** column for the `--court` / court-code arguments
+elsewhere.
+
+### `install-skills` — wire up your AI assistant
+
+```bash
+bharat-courts install-skills
+```
+
+Copies the bundled Agent Skill into `.claude/skills/bharat-courts/` in the
+current directory, so a Claude-based assistant can call the SDK on your behalf
+in plain English. See the [lawyer guides](../lawyers/claude-code.md) for what to
+do next.
+
+## `hcservices` — High Court Services portal
+
+Commands for `hcservices.ecourts.gov.in`. Most take a **court code** as a
+positional argument (run `bharat-courts courts --type hc` to list them). The
+discovery commands (`benches`, `case-types`) need no CAPTCHA; the rest do, and
+are auto-retried.
+
+| Command | Purpose | Key options |
+|---------|---------|-------------|
+| `benches COURT` | List benches for a High Court | — |
+| `case-types COURT` | List case-type codes for a bench | `--bench` (default `1`) |
+| `search COURT` | Case status by case number | `--case-type` ·`--case-number` · `--year` (all required) · `--bench` |
+| `search-by-party COURT` | Case status by party name | `--party` · `--year` (both required) · `--status pending\|disposed\|both` · `--bench` |
+| `orders COURT` | Orders for a case | `--case-type` · `--case-number` · `--year` (required) · `--bench` · `--download DIR` |
+| `cause-list COURT` | Cause-list PDFs | `--date DD-MM-YYYY` · `--criminal` · `--bench` · `--download DIR` |
+
+```bash
+# Discover bench codes, then case-type codes (no CAPTCHA)
+bharat-courts hcservices benches bombay
+bharat-courts hcservices case-types delhi --bench 1
+
+# Look up a writ petition by its numeric case-type code
+bharat-courts hcservices search delhi --case-type 134 --case-number 1 --year 2024
+
+# All orders, saving the PDFs to ./orders/
+bharat-courts hcservices orders delhi \
+  --case-type 134 --case-number 1 --year 2024 --download ./orders/
+```
+
+`benches` and `case-types` print `code  name` pairs (or a JSON object with
+`--json`). The `--download` option on `orders` and `cause-list` writes each PDF
+to the directory and, in JSON mode, adds a `pdf_local_path` field to each row.
+
+!!! note "Numeric case-type codes"
+
+    `--case-type` wants the **numeric** code from `case-types`, e.g. `134` for
+    `W.P.(C)` on Delhi HC — not the label. Always run `case-types` first.
+
+## `districtcourts` — District Courts portal
+
+Commands for `services.ecourts.gov.in` (700+ court complexes). District courts
+have no static codes; you discover the hierarchy
+**State → District → Complex → Establishment** with the listing commands, then
+feed those codes into the search/orders/cause-list commands.
+
+| Command | Purpose | Required options |
+|---------|---------|------------------|
+| `states` | List states/UTs | — |
+| `districts` | Districts in a state | `--state` |
+| `complexes` | Court complexes in a district | `--state` · `--dist` |
+| `establishments` | Establishments in a complex | `--state` · `--dist` · `--complex` |
+| `case-types` | Case-type codes for a court | `--state` · `--dist` · `--complex` (`--est` optional) |
+| `courts` | Courts for cause-list lookup | `--state` · `--dist` · `--complex` (`--est` optional) |
+| `search` | Case status by case number | `--state` · `--dist` · `--complex` · `--case-type` · `--case-number` · `--year` (`--est` optional) |
+| `search-by-party` | Case status by party | `--state` · `--dist` · `--complex` · `--party` · `--year` (`--est` optional, `--status`) |
+| `orders` | Orders for a case | as `search`, plus `--download DIR` |
+| `cause-list` | Cause-list entries | `--state` · `--dist` · `--complex` · `--court-no` (`--est`, `--court-name`, `--date`, `--criminal`) |
+
+```bash
+# Walk the hierarchy
+bharat-courts districtcourts states
+bharat-courts districtcourts districts --state 8                  # Bihar
+bharat-courts districtcourts complexes --state 8 --dist 1         # Patna
+bharat-courts districtcourts case-types --state 8 --dist 1 --complex 1080010 --est 2
+
+# Search using the discovered codes (case-type is the compound "<code>^<est>")
+bharat-courts districtcourts search \
+  --state 8 --dist 1 --complex 1080010 --est 2 \
+  --case-type "89^2" --case-number 100 --year 2024
+
+# Cause list — --court-no comes from the `courts` subcommand
+bharat-courts districtcourts cause-list \
+  --state 8 --dist 1 --complex 1080010 --est 2 \
+  --court-no "1@2" --date 20-03-2026
+```
+
+!!! warning "Pass compound codes verbatim"
+
+    The portal returns case-type codes like `89^2` and court codes like `1@2`.
+    Pass them back exactly as given — do not strip the `^N` or `@N` suffix.
+    `--court-name` is auto-resolved from `--court-no` if you leave it blank.
+
+`--status` (on `search-by-party`) accepts `pending`, `disposed`, or `both`
+(default `both`).
+
+## `calcuttahc` — Calcutta High Court website
+
+A single command against `calcuttahighcourt.gov.in`, which has better PDF
+coverage for Calcutta HC cases than the eCourts portal.
+
+| Command | Purpose | Options |
+|---------|---------|---------|
+| `search` | Search orders/judgments by case number | `--case-type` · `--case-number` · `--year` (required) · `--establishment` · `--download DIR` |
+
+`--establishment` is one of `appellate` (default), `original`, `jalpaiguri`, or
+`portblair`.
+
+```bash
+bharat-courts calcuttahc search \
+  --case-type 12 --case-number 12886 --year 2024 \
+  --establishment appellate --download ./calcutta/
+```
+
+In JSON mode the output is an object with `case_info` and an `orders` array;
+downloaded PDFs add a `pdf_local_path` to each order. CAPTCHA is auto-retried
+(tune with the global `--captcha-attempts`).
+
+## `judgments` — eCourts judgment search
+
+Full-text search against `judgments.ecourts.gov.in`. CAPTCHA-gated.
+
+| Command | Purpose | Key options |
+|---------|---------|-------------|
+| `search` | One page of results | `--text` (required) · `--page` · `--page-size` · `--search-opt PHRASE\|ANY\|ALL` · `--court-type` · `--download DIR` |
+| `search-all` | Walk every page | `--text` (required) · `--page-size` · `--max-pages` (0 = all) · `--search-opt` · `--court-type` · `--download DIR` |
+
+`--court-type` is `2` for High Courts (default) or `3` for the Supreme Court
+report. `--search-opt` controls phrase matching.
+
+```bash
+# First page of phrase results
+bharat-courts judgments search --text "right to privacy" --page-size 25
+
+# Walk up to 5 pages and download every PDF
+bharat-courts judgments search-all \
+  --text "land acquisition" --max-pages 5 --download ./judgments/
+```
+
+The `search` JSON output wraps the items in pagination metadata
+(`total_count`, `page`, `page_size`, `has_next`, `total_pages`, `items`);
+`search-all` returns `{"total_items": N, "items": [...]}`.
+
+## `sci` — Supreme Court feed
+
+| Command | Purpose | Options |
+|---------|---------|---------|
+| `recent` | Most recent SC judgments (homepage feed) | `--limit` (max 50) · `--download DIR` |
+
+No CAPTCHA — this scrapes the "Latest Judgements / Orders" feed on
+`www.sci.gov.in`.
+
+```bash
+bharat-courts sci recent --limit 10
+bharat-courts sci recent --limit 50 --download ./sci/
+```
+
+!!! note "Recent feed only"
+
+    The SCI client only exposes the homepage feed today; case-number and
+    party-name search are not yet wired up. For older Supreme Court matters,
+    use `bharat-courts archive` or `bharat-courts find --court sci`.
+
+## `archive` — historical AWS Open Data archive
+
+Offline-friendly queries over the public S3 buckets (SCI 1950→present + 25 HCs).
+No CAPTCHA, no rate limits. Requires the `archive` extra — every command in this
+group prints an install hint and exits non-zero if it is missing.
+
+| Command | Purpose | Key options |
+|---------|---------|-------------|
+| `query` | Search metadata | `--court` · `--year` · `--judge` · `--party` · `--citation` · `--cnr` · `--limit` |
+| `get` | Look up one CNR; optionally save its PDF | `--cnr` (required) · `--pdf` · `--out` · `--language` |
+| `download` | Pre-warm the cache (SCI year tars only) | `--court` (default `sci`) · `--year` (required) · `--language` |
+| `cache` | Show cache stats or clear it | `--clear` |
+| `count` | Row counts per bucket | `--court` · `--year` |
+
+```bash
+# Every Delhi HC judgment by a named judge in a date range
+bharat-courts archive query --court delhi --judge "sanjeev" --year 2018-2022 --limit 50
+
+# Resolve a CNR and save its PDF (SCI honours --language)
+bharat-courts archive get --cnr ESCR010000301950 --pdf --out ./judgment.pdf
+bharat-courts archive get --cnr DLHC010230802020 --pdf --out ./pdfs/
+
+# Pre-warm a whole SCI year before a batch of fetches
+bharat-courts archive download --court sci --year 2020
+
+# How many rows are in the archive?
+bharat-courts archive count --court sci --year 2020
+
+# Cache housekeeping
+bharat-courts archive cache
+bharat-courts archive cache --clear
+```
+
+`get` without `--pdf` prints (or JSON-emits) just the metadata for the CNR.
+`download` only supports SCI year tars — High Court PDFs are fetched on demand
+by `get`, so `download --court delhi` will refuse with a clear message.
+
+!!! info "Archive freshness"
+
+    The buckets lag live filings by 2–3 months (SCI updates bi-monthly, HCs
+    quarterly). For very recent judgments, use the live commands above or
+    `bharat-courts find` and let routing decide. See the
+    [Archive guide](archive.md) for cache sizing and language codes.
+
+## Where next
+
+- [Quickstart](../start/quickstart.md) — the five-minute tour of the SDK and CLI.
+- [The `Judgments` facade](facade.md) — the Python equivalent of `find`, with
+  the full routing matrix.
+- [Configuration](../start/configuration.md) — environment variables for cache
+  size, metadata TTL, and rate limits.

--- a/docs/guides/district-courts.md
+++ b/docs/guides/district-courts.md
@@ -1,0 +1,241 @@
+# District Courts
+
+`DistrictCourtClient` is the live client for the District Courts portal at
+`services.ecourts.gov.in` — the national eCourts service that covers **700+
+district and taluka courts** across every state and union territory. Use it for
+live case status, court orders, and cause lists at the district level.
+
+!!! info "When to use this client"
+    Reach for `DistrictCourtClient` when the question is about a **district-court
+    case** and needs **current** state — "what's the status of this case", "what
+    are the latest orders", "show me tomorrow's cause list". For finding judgments
+    (historical or by judge/keyword) start with the [`Judgments` facade](facade.md)
+    instead. For High Court cases, see [High Courts](high-courts.md).
+
+## The 4-level hierarchy
+
+Unlike High Courts (which you address with a single static code via `get_court()`),
+district courts are organised as a four-level cascade. You must resolve all four
+levels before you can search:
+
+```text
+State  →  District  →  Court Complex  →  Establishment
+ "8"       "1"          "1080010"          "2"
+ Bihar     Patna        Civil Court        (a specific court within the complex)
+```
+
+- **State** — the state or UT (e.g. `"8"` = Bihar). 36 in total.
+- **District** — a district within that state (e.g. `"1"` = Patna).
+- **Court Complex** — a physical court complex within the district. A complex may
+  contain one or many *establishments*.
+- **Establishment** — a specific court within a complex. Only required for some
+  complexes (see the note on the complex value format below).
+
+Because these codes are not static and differ from district to district, you
+**discover them dynamically** by walking the cascade — each step's output feeds
+the next.
+
+### The discovery flow
+
+```text
+list_states()                          → {"8": "Bihar", ...}
+list_districts("8")                    → {"1": "Patna", ...}
+list_complexes("8", "1")               → {"1080010@2,3,4@Y": "Civil Court, Patna Sadar", ...}
+parse_complex_value("1080010@2,3,4@Y") → ("1080010", ["2","3","4"], True)
+list_establishments("8","1","1080010") → {"2": "...", ...}   # only if flag is Y
+list_case_types("8","1","1080010","2") → {"1": "Civil Suit", ...}
+```
+
+The discovery methods are **CAPTCHA-free** — only the actual searches
+(`case_status`, `case_status_by_party`, `court_orders`, `cause_list`) require a
+CAPTCHA, which the client solves and retries automatically.
+
+!!! note "Court complex value format: `code@ests@flag`"
+    `list_complexes()` returns dropdown **values** in the compound form
+    `complex_code@est_codes@flag`, for example `1080010@2,3,4@Y`:
+
+    - `1080010` — the raw complex code
+    - `2,3,4` — the establishment codes contained in this complex
+    - `Y` — the "needs establishment" flag (`Y` means you must pick an
+      establishment; otherwise establishment selection is not required)
+
+    Always run the raw value through
+    `parse_complex_value()` before passing it to the search methods — they expect
+    the **bare** `court_complex_code` (`1080010`), not the compound value.
+
+## Method reference
+
+All search methods take `state_code`, `dist_code`, `court_complex_code`, and an
+optional `est_code` (resolved via the discovery methods above). Search methods are
+keyword-only (`*`) — pass them by name.
+
+| Method | CAPTCHA | Returns | Description |
+|--------|---------|---------|-------------|
+| `list_states()` | No | `dict[str, str]` | All states/UTs `{code: name}` |
+| `list_districts(state_code)` | No | `dict[str, str]` | Districts for a state |
+| `list_complexes(state_code, dist_code)` | No | `dict[str, str]` | Court complexes; values are `code@ests@flag` |
+| `list_establishments(state_code, dist_code, court_complex_code)` | No | `dict[str, str]` | Establishments (use when complex flag is `Y`) |
+| `list_case_types(state_code, dist_code, court_complex_code, est_code="")` | No | `dict[str, str]` | Case type codes; keys are compound `"<case_type>^<est_code>"` |
+| `case_status(*, state_code, dist_code, court_complex_code, est_code="", case_type, case_number, year)` | Yes | `list[CaseInfo]` | Search by case number |
+| `case_status_by_party(*, state_code, dist_code, court_complex_code, est_code="", party_name, year, status_filter="Both")` | Yes | `list[CaseInfo]` | Search by party name |
+| `court_orders(*, state_code, dist_code, court_complex_code, est_code="", case_type, case_number, year)` | Yes | `list[CaseOrder]` | Orders for a case |
+| `cause_list(*, state_code, dist_code, court_complex_code, est_code="", court_no, court_name="", causelist_date="", civil=True)` | Yes | `list[CauseListEntry]` | Cause-list entries for a court |
+| `list_cause_list_courts(state_code, dist_code, court_complex_code, est_code="")` | No | `dict[str, str]` | Courts dropdown for cause-list lookup |
+
+!!! tip "Helpful defaults"
+    - `year` is **mandatory** for `case_status_by_party` (the server rejects an
+      empty year), and `party_name` must be at least 3 characters.
+    - `status_filter` accepts `"Pending"`, `"Disposed"`, or `"Both"` (default).
+    - `cause_list` takes a `court_no` (the option *value* from
+      `list_cause_list_courts`) and a `court_name`. If you leave `court_name`
+      empty, the client looks it up for you from `court_no` — the portal validates
+      against the display name, so this saves a manual step.
+    - `causelist_date` is `DD-MM-YYYY` and defaults to today.
+
+!!! warning "Case type codes are compound — don't strip the suffix"
+    `list_case_types()` returns codes in the portal's compound
+    `"<case_type>^<est_code>"` form (e.g. `"89^2": "ADMINISTRATIVE SUITE"`). Pass
+    the **full** compound string back as `case_type` to `case_status` and
+    `court_orders`. Stripping the `^…` suffix will break the lookup.
+
+## Worked example
+
+This walks the full cascade — discover the hierarchy, parse the complex value,
+list case types, then run searches. CAPTCHA solving and retries happen
+automatically when an [OCR solver](captcha.md) is configured (the default when
+`bharat-courts[ocr]` is installed).
+
+```python
+import asyncio
+from bharat_courts import DistrictCourtClient
+from bharat_courts.captcha.ocr import OCRCaptchaSolver
+from bharat_courts.districtcourts.parser import parse_complex_value
+
+
+async def main():
+    solver = OCRCaptchaSolver()
+
+    async with DistrictCourtClient(captcha_solver=solver) as client:
+        # 1. Discover the court hierarchy (no CAPTCHA)
+        states = await client.list_states()
+        # {"8": "Bihar", "7": "Delhi", ...}
+
+        districts = await client.list_districts("8")        # Bihar
+        # {"1": "Patna", "35": "Gaya", ...}
+
+        complexes = await client.list_complexes("8", "1")   # Patna
+        # {"1080010@2,3,4@Y": "Civil Court, Patna Sadar", ...}
+
+        # 2. Parse the complex value → (complex_code, est_codes, needs_establishment)
+        complex_val = next(iter(complexes))
+        complex_code, est_codes, needs_est = parse_complex_value(complex_val)
+        est_code = est_codes[0] if needs_est else ""
+
+        # 2b. If the complex needs an establishment, list them and pick one
+        if needs_est:
+            establishments = await client.list_establishments("8", "1", complex_code)
+            # {"2": "Civil Judge Sr. Div.", ...}
+            est_code = next(iter(establishments))
+
+        # 3. Discover case types for this court (no CAPTCHA)
+        case_types = await client.list_case_types("8", "1", complex_code, est_code)
+        # {"1^2": "Civil Suit", "89^2": "ADMINISTRATIVE SUITE", ...}
+
+        # 4. Search by party name (CAPTCHA auto-solved and retried)
+        cases = await client.case_status_by_party(
+            state_code="8", dist_code="1",
+            court_complex_code=complex_code, est_code=est_code,
+            party_name="kumar", year="2024",
+        )
+        for c in cases:
+            print(f"{c.case_number}: {c.petitioner} vs {c.respondent}  [{c.cnr_number}]")
+
+        # 5. Search by case number
+        by_number = await client.case_status(
+            state_code="8", dist_code="1",
+            court_complex_code=complex_code, est_code=est_code,
+            case_type="1", case_number="100", year="2024",
+        )
+
+        # 6. Get orders for a case
+        orders = await client.court_orders(
+            state_code="8", dist_code="1",
+            court_complex_code=complex_code, est_code=est_code,
+            case_type="1", case_number="100", year="2024",
+        )
+        for o in orders:
+            print(f"{o.order_date} | {o.order_type} | {o.judge} | {o.pdf_url}")
+
+        # 7. Cause list — court_name is auto-resolved from court_no if omitted
+        entries = await client.cause_list(
+            state_code="8", dist_code="1",
+            court_complex_code=complex_code, est_code=est_code,
+            court_no="1@2", civil=True,
+        )
+        for e in entries:
+            print(f"{e.serial_number}. {e.case_number}: {e.petitioner} vs {e.respondent}")
+
+
+asyncio.run(main())
+```
+
+### Parsing the complex value
+
+`parse_complex_value(value)` lives in `bharat_courts.districtcourts.parser` and is
+the bridge between the raw dropdown value and the bare codes the search methods
+expect:
+
+```python
+from bharat_courts.districtcourts.parser import parse_complex_value
+
+parse_complex_value("1080010@2,3,4@Y")
+# → ("1080010", ["2", "3", "4"], True)   # needs an establishment
+
+parse_complex_value("1080099@@N")
+# → ("1080099", [], False)               # establishment not required
+```
+
+The third element is the **`needs_establishment`** boolean (the flag `Y`/`N`).
+When it is `True`, call `list_establishments()` and pass a chosen `est_code` to the
+search methods; when `False`, leave `est_code=""`.
+
+## What you get back
+
+| Method group | Model | Useful fields |
+|---|---|---|
+| `case_status`, `case_status_by_party` | `CaseInfo` | `case_number`, `case_type`, `cnr_number`, `petitioner`, `respondent`, `registration_date`, `status`, `next_hearing_date` |
+| `court_orders` | `CaseOrder` | `order_date`, `order_type`, `judge`, `pdf_url` |
+| `cause_list` | `CauseListEntry` | `serial_number`, `case_number`, `petitioner`, `respondent`, `advocate_petitioner`, `court_number`, `judge` |
+
+!!! note "District cause lists return structured entries, not PDFs"
+    Unlike the High Court Services portal (which returns one PDF per bench),
+    district-court cause lists come back as individual `CauseListEntry` rows — one
+    per listed case. There is no PDF to download for these.
+
+District-court order PDFs (`CaseOrder.pdf_url`) are not always uploaded on
+eCourts even when the case exists. The client returns the URL it finds; the
+download itself may fail server-side if the file was never published.
+
+## How it works under the hood
+
+The portal is session-and-token driven. Each AJAX response carries a rotating
+`app_token` that must accompany the next request, and the CAPTCHA is pinned to the
+PHP session. The client handles all of this for you:
+
+1. `GET` the home page to establish the `SERVICES_SESSID` cookie.
+2. Fetch an initial `app_token`.
+3. Walk the cascade dropdowns (`fillDistrict`, `fillcomplex`,
+   `fillCourtEstablishment`, `fillCaseType`).
+4. Store the court selection server-side (`set_data`) before any search.
+5. Solve the CAPTCHA and submit the query.
+
+On a CAPTCHA rejection the client **creates a fresh session** (new cookies, new
+CAPTCHA), re-establishes the court selection, and retries — up to 5 attempts by
+default. You do not manage tokens, cookies, or retries yourself.
+
+## See also
+
+- [CAPTCHA handling](captcha.md) — solver options and accuracy.
+- [High Courts](high-courts.md) — the sibling client for HC Services.
+- [Calcutta High Court](calcutta-hc.md) — direct-website client.
+- [Clients API reference](../reference/clients.md) — full signatures.

--- a/docs/guides/facade.md
+++ b/docs/guides/facade.md
@@ -1,0 +1,286 @@
+# The Judgments facade
+
+`Judgments` is the federated entry point for judgment search. Most callers want
+*a judgment matching some criteria* and don't care whether it comes from the live
+eCourts portal or the AWS Open Data archive. `Judgments` exposes one method —
+`find(...)` — that takes any combination of filters, routes to the right backend,
+and returns a uniform `list[Judgment]`.
+
+This guide is the deep reference for that facade. For the backends it sits on top
+of, see the [archive guide](archive.md) and the
+[judgment-search guide](judgment-search.md); for the generated API surface see the
+[facade API reference](../reference/facade.md).
+
+## Why one entry point
+
+There are two judgment backends with very different shapes:
+
+- **Live** (`JudgmentSearchClient`) — the only backend that does full-body text
+  search. CAPTCHA-gated, rate-limited.
+- **Archive** (`ArchiveClient`) — DuckDB over the public S3 buckets. No CAPTCHA, no
+  rate limits, partition-pruned, but lags 2–3 months and can only match text against
+  titles.
+
+Choosing between them by hand means reasoning about CAPTCHAs, partition pruning, and
+freshness on every call. `Judgments.find()` makes that decision for you from the
+shape of the query, logs which way it went, and hands back `Judgment` objects that
+each carry a `.source` field (`"archive"` or `"live"`) so you always know the origin.
+
+```python
+import asyncio
+from bharat_courts import Judgments
+
+async def main():
+    async with Judgments() as j:
+        hits = await j.find(judge="chandrachud", year=2020, court="sci", limit=10)
+        for r in hits:
+            print(r.decision_date, r.case_id, r.title, f"[{r.source}]")
+
+asyncio.run(main())
+```
+
+## Routing decision table (auto mode)
+
+With the default `source="auto"`, `find()` inspects three things — whether `cnr` is
+set, whether `text` is set, and whether any *structured* filter
+(`court`, `year`, `judge`, `party`, `citation`) is set — and resolves a backend:
+
+| `cnr` | `text` | structured | → backend | Why |
+|---|---|---|---|---|
+| set | any | any | **archive** | CNR prefix → court → partition; instant lookup |
+| — | set | no | **live** | Only the live portal does full-body text search |
+| — | — | yes | **archive** | Partition-pruned, no CAPTCHA |
+| — | set | yes | **archive** | `text` folds into a title-substring match |
+| — | — | — | `ValueError` | Need at least one filter |
+
+The precedence is exactly that order: a `cnr` always wins, then text-only goes live,
+then anything structured goes to the archive. Each decision is logged at INFO under
+the `bharat_courts.facade` logger (`Judgments.find routing → archive`), so routing is
+debuggable in production.
+
+!!! warning "Mixed `text` + structured does a title match, not full-text"
+    When you pass `text` *together with* a structured filter, `find()` routes to the
+    **archive**, not live. The archive cannot do full-body search, so `text` is folded
+    into the `party` slot, which matches against the title (and, for SCI, party
+    columns). A query like `find(text="tata", court="delhi", year=2020)` therefore
+    returns judgments whose *title* contains "tata" — not every Delhi 2020 judgment
+    that *mentions* Tata in the body. This is intentional (it avoids silently burning
+    a CAPTCHA and 30 seconds on a live call), but it is a real limitation: if you need
+    true full-body search, pass `source="live"` with `text` alone.
+
+### Forcing a backend
+
+Set `source="archive"` or `source="live"` to bypass auto-routing entirely. The forced
+value short-circuits before any of the auto rules are consulted.
+
+```python
+# Force live (e.g. for a case decided last month, before the archive catches up)
+recent = await j.find(text="anticipatory bail", source="live", limit=5)
+
+# Force archive even though you only passed text (title match only)
+hist = await j.find(text="kesavananda", source="archive", limit=20)
+```
+
+!!! note "`source` is per-call, not a constructor setting"
+    There is no `default_source` on `Judgments()`. Each override is explicit at the
+    call site, so it's always obvious from the code which backend a given query used.
+
+## `find()` signature
+
+```python
+async def find(
+    self,
+    *,
+    text: str | None = None,
+    court: Court | str | None = None,
+    year: int | tuple[int, int] | None = None,
+    judge: str | None = None,
+    party: str | None = None,
+    citation: str | None = None,
+    cnr: str | None = None,
+    source: Source = "auto",      # Literal["auto", "archive", "live"]
+    limit: int = 50,
+) -> list[Judgment]:
+```
+
+All parameters are keyword-only.
+
+| Parameter | Type | Meaning |
+|---|---|---|
+| `text` | `str` | Free-text query. Alone → live full-text search. With a structured filter → archive title match. |
+| `court` | `Court \| str` | A `Court` object or a registry code (`"delhi"`, `"sci"`, …). Structured filter. |
+| `year` | `int \| tuple[int, int]` | A single year, or an inclusive `(start, end)` range. Structured filter. |
+| `judge` | `str` | Judge-name substring. Structured filter. |
+| `party` | `str` | Party-name substring (title + party columns on the archive). Structured filter. |
+| `citation` | `str` | Citation substring. Structured filter. |
+| `cnr` | `str` | Case Number Record id. Routes straight to the archive via its 4-letter prefix. |
+| `source` | `"auto" \| "archive" \| "live"` | Routing override. Default `"auto"`. |
+| `limit` | `int` | Max rows. Default `50`. For the live route, page size is capped at 25 internally and trimmed to `limit`. |
+
+!!! info "Archive caveats inherited by structured queries"
+    Structured queries land on `ArchiveClient.search`, so its limits apply: HC parquet
+    has no separate party/citation columns, so on High Courts `party=` matches the
+    title only and `citation=` is silently ignored. SCI behaves as documented. See the
+    [archive guide](archive.md) for the full list.
+
+## Worked examples, one per route
+
+### CNR → archive
+
+A CNR alone routes to the archive; the 4-letter prefix resolves the court and
+partition, so the lookup is effectively instant and no other filter is needed.
+
+```python
+async with Judgments() as j:
+    hits = await j.find(cnr="DLHC010230802020")
+    if hits:
+        print(hits[0].title, hits[0].decision_date)
+```
+
+### Text only → live
+
+Free text with no structured filter is the one case that goes to the live portal,
+because it is the only backend that searches the full body of a judgment.
+
+```python
+async with Judgments() as j:
+    for r in await j.find(text="right to privacy", limit=5):
+        print(r.decision_date, r.title, f"[{r.source}]")  # source == "live"
+```
+
+### Structured only → archive
+
+Any structured filter — judge, party, year, court, or citation — with no `text` goes
+to the archive: partition-pruned, no CAPTCHA, fast.
+
+```python
+async with Judgments() as j:
+    hits = await j.find(judge="chandrachud", year=(2018, 2024), court="sci", limit=10)
+    for r in hits:
+        print(r.decision_date, r.citation, r.disposal_nature)
+```
+
+### Text + structured → archive (title match)
+
+Combining `text` with a structured filter stays on the archive and folds `text` into a
+title match. See the warning above for the limitation.
+
+```python
+async with Judgments() as j:
+    # Delhi HC judgments from 2020 whose TITLE contains "tata"
+    hits = await j.find(text="tata", court="delhi", year=2020)
+```
+
+### Nothing → `ValueError`
+
+```python
+await j.find()  # raises ValueError: needs at least one of text, cnr, or a
+                # structured filter (court / year / judge / party / citation)
+```
+
+## `fetch_pdf()`
+
+```python
+async def fetch_pdf(
+    self,
+    judgment_or_cnr: Judgment | str,
+    *,
+    language: str = "english",
+) -> bytes:
+```
+
+Pass either a `Judgment` (from the archive route) or a CNR string. The facade routes
+both to `ArchiveClient.fetch_pdf`, which returns the raw PDF bytes. SCI supports
+regional languages via `language=` (`"hindi"`, `"tamil"`, `"gujarati"`, …); HC PDFs
+are English only.
+
+```python
+async with Judgments() as j:
+    hits = await j.find(cnr="DLHC010230802020")
+    pdf = await j.fetch_pdf(hits[0])              # or: await j.fetch_pdf("DLHC010230802020")
+    with open("judgment.pdf", "wb") as f:
+        f.write(pdf)
+```
+
+!!! warning "Live `Judgment` objects cannot be fetched through the facade"
+    If you pass a `Judgment` whose `.source == "live"`, `fetch_pdf()` raises
+    `NotImplementedError`. The live download path needs the *original*
+    `JudgmentResult` instance — it carries CAPTCHA-validated session state that a bare
+    `Judgment` does not. The documented workaround is to call the live client directly:
+
+    ```python
+    from bharat_courts import JudgmentSearchClient
+
+    async with JudgmentSearchClient() as client:
+        result = await client.search("right to privacy")
+        jr = result.items[0]                      # a JudgmentResult, session-bound
+        jr = await client.download_pdf(jr)        # fills jr.pdf_bytes in place
+        with open("judgment.pdf", "wb") as f:
+            f.write(jr.pdf_bytes)
+    ```
+
+    Do not try to round-trip a live PDF through `Judgments` — the session continuity
+    the live portal needs lives on the `JudgmentResult`, not on the unified `Judgment`.
+
+## `live_to_judgment()` helper
+
+When you call the live client directly but want the unified `Judgment` shape (for
+example, to mix live and archive results in one list), use the module-level helper
+`live_to_judgment(jr: JudgmentResult) -> Judgment`. This is exactly what `find()` uses
+internally on the live route.
+
+```python
+from bharat_courts import JudgmentSearchClient
+from bharat_courts.facade import live_to_judgment
+
+async with JudgmentSearchClient() as client:
+    result = await client.search("constitution")
+    unified = [live_to_judgment(jr) for jr in result.items]  # list[Judgment]
+```
+
+Field mapping:
+
+| `JudgmentResult` | `Judgment` |
+|---|---|
+| `title` | `title` |
+| `court_name` | `court_name_raw`; also resolved into `court` via the courts registry when a match is found |
+| `source_id` | `cnr` (the judgments portal uses CNR as its row id) |
+| `judges` | `judges` |
+| `judgment_date` | `decision_date` (and its `.year` → `year`) |
+| `citation` | `citation` (when non-empty) |
+| `pdf_url` | `pdf_path` (raw path only — live download still needs the original `JudgmentResult`) |
+| `metadata["disposal_nature"]` | `disposal_nature` |
+| `metadata["registration_date"]` | `date_of_registration` (parsed from `YYYY-MM-DD`) |
+
+The resulting `Judgment` always has `source="live"`, which is what later makes
+`fetch_pdf()` reject it (see the warning above).
+
+## Lazy backends and extras
+
+`Judgments()` owns both an `ArchiveClient` and a `JudgmentSearchClient`, but neither is
+created until a query actually routes to it. This means you only pay for — and only
+need to install — the side you use:
+
+```bash
+pip install 'bharat-courts[archive]'   # archive backend (DuckDB)
+pip install 'bharat-courts[ocr]'       # live backend (ddddocr CAPTCHA solving)
+pip install 'bharat-courts[all]'       # everything
+```
+
+For the full federated experience, install **both** `[archive]` and `[ocr]` so
+`find()` can use either backend. If a query routes to the archive but the `[archive]`
+extra isn't installed, the facade raises a clear `ImportError` telling you exactly
+which extra to install.
+
+!!! tip "Always use the async context manager"
+    Open the facade with `async with Judgments() as j:`. On exit it closes whichever
+    backends were lazily created — `ArchiveClient.close()` for the archive, and a clean
+    `__aexit__` on the live client (which it keeps alive across `find()` calls so a
+    session and CAPTCHA aren't re-established every time). If you can't use a `with`
+    block, call `await j.aclose()` yourself when done.
+
+## See also
+
+- [Historical archive guide](archive.md) — the backend behind every structured and CNR query.
+- [Judgment search guide](judgment-search.md) — the live full-text backend and direct PDF download.
+- [Facade API reference](../reference/facade.md) — generated signatures for `Judgments`, `Source`, and `live_to_judgment`.

--- a/docs/guides/high-courts.md
+++ b/docs/guides/high-courts.md
@@ -1,0 +1,266 @@
+# High Courts via `HCServicesClient`
+
+`HCServicesClient` is the live client for **hcservices.ecourts.gov.in** — the official
+eCourts High Court Services portal. Use it for things that only the live portal can answer:
+current case status, the next hearing date, in-progress orders, and today's cause list.
+
+!!! tip "Looking for a judgment, not live status?"
+
+    If you just want to *find a judgment* (by judge, party, year, citation, or CNR) and
+    download its PDF, start with the federated [`Judgments` facade](facade.md) instead — it
+    picks the historical [archive](archive.md) or the live portal for you and never needs a
+    CAPTCHA for archive queries. Drop down to `HCServicesClient` when you need a portal-only
+    feature: **case status, cause lists, or current orders**.
+
+This client covers all 25 High Courts plus the Supreme Court, selected with a static court
+code via `get_court(...)`.
+
+## Picking a court
+
+Every High Court is identified by a short code. Resolve it to a `Court` object once and pass
+it to each method:
+
+```python
+from bharat_courts import get_court
+
+court = get_court("delhi")     # or "bombay", "calcutta", "madras", ...
+print(court.name)              # "Delhi High Court"
+print(court.state_code)        # "26"
+```
+
+### Available High Courts
+
+| Code | Court | State Code |
+|------|-------|------------|
+| `delhi` | Delhi High Court | 26 |
+| `bombay` | Bombay High Court | 1 |
+| `calcutta` | Calcutta High Court | 16 |
+| `madras` | Madras High Court | 10 |
+| `allahabad` | Allahabad High Court | 13 |
+| `karnataka` | Karnataka High Court | 3 |
+| `kerala` | Kerala High Court | 4 |
+| `gujarat` | Gujarat High Court | 17 |
+| `punjab` | Punjab & Haryana High Court | 22 |
+| `rajasthan` | Rajasthan High Court | 9 |
+| `telangana` | Telangana High Court | 29 |
+| `andhra` | Andhra Pradesh High Court | 2 |
+| `patna` | Patna High Court | 8 |
+| `gauhati` | Gauhati High Court | 6 |
+| `orissa` | Orissa High Court | 11 |
+| `mp` | Madhya Pradesh High Court | 23 |
+| `jharkhand` | Jharkhand High Court | 7 |
+| `chhattisgarh` | Chhattisgarh High Court | 18 |
+| `himachal` | Himachal Pradesh High Court | 5 |
+| `uttarakhand` | Uttarakhand High Court | 15 |
+| `jammu` | J&K High Court | 12 |
+| `manipur` | Manipur High Court | 25 |
+| `meghalaya` | Meghalaya High Court | 21 |
+| `sikkim` | Sikkim High Court | 24 |
+| `tripura` | Tripura High Court | 20 |
+| `sci` | Supreme Court of India | 0 |
+
+## CAPTCHA setup
+
+The HC Services portal is CAPTCHA-gated. Search and order/cause-list methods need a CAPTCHA
+solver; discovery methods (`list_benches`, `list_case_types`) and PDF download do not.
+
+If you installed `bharat-courts[ocr]`, you don't have to do anything — the client
+auto-detects the `ddddocr` solver. To be explicit (or to use a different solver), pass one in:
+
+```python
+from bharat_courts import HCServicesClient
+from bharat_courts.captcha.ocr import OCRCaptchaSolver
+
+async with HCServicesClient(captcha_solver=OCRCaptchaSolver()) as client:
+    ...
+```
+
+CAPTCHA failures are retried automatically — the client creates a fresh portal session on
+each attempt because the image is pinned to the PHP session. See the
+[CAPTCHA guide](captcha.md) for the full set of solvers (OCR, ONNX, manual, custom).
+
+## Method reference
+
+| Method | CAPTCHA | Returns | Description |
+|--------|---------|---------|-------------|
+| `list_benches(court)` | No | `dict[str, str]` | Available benches (`{code: name}`) |
+| `list_case_types(court, *, bench_code="1")` | No | `dict[str, str]` | Case type codes for a bench |
+| `case_status(court, *, case_type, case_number, year, bench_code="1")` | Yes | `list[CaseInfo]` | Search by case number |
+| `case_status_by_party(court, *, party_name, year, bench_code="1", status_filter="Both")` | Yes | `list[CaseInfo]` | Search by party name |
+| `court_orders(court, *, case_type, case_number, year, bench_code="1")` | Yes | `list[CaseOrder]` | Get orders for a case |
+| `cause_list(court, *, civil=True, bench_code="1", causelist_date="")` | Yes | `list[CauseListPDF]` | Cause list PDFs (date format `DD-MM-YYYY`) |
+| `download_order_pdf(pdf_url)` | No | `bytes` | Download an order/judgment PDF |
+
+!!! warning "`year` is mandatory for party-name search"
+
+    `case_status_by_party` **requires** the registration `year`. If you omit it, the portal
+    returns an `ERROR_VAL` response rather than results — this is a server-side rule, not a
+    CAPTCHA failure. (`case_status` and `court_orders` also take a required `year`.) The
+    `party_name` should be at least 3 characters.
+
+For the full data-model fields returned by each method, see the
+[client reference](../reference/clients.md).
+
+## Examples
+
+All methods are async. Each example assumes `bharat-courts[ocr]` is installed so the default
+solver is available.
+
+### Discover benches and case types (no CAPTCHA)
+
+Case type codes are numeric and vary by court, so discover them before searching. Benches and
+case types are returned as `{code: name}` dictionaries and need no CAPTCHA.
+
+```python
+import asyncio
+from bharat_courts import get_court, HCServicesClient
+
+
+async def main():
+    court = get_court("delhi")
+    async with HCServicesClient() as client:
+        benches = await client.list_benches(court)
+        # e.g. {"1": "Principal Bench at Delhi", ...}
+        for code, name in benches.items():
+            print(f"{code}: {name}")
+
+        case_types = await client.list_case_types(court)  # default bench_code="1"
+        # e.g. {"134": "W.P.(C)(CIVIL WRITS)-134", ...}
+        for code, name in case_types.items():
+            print(f"{code}: {name}")
+
+
+asyncio.run(main())
+```
+
+### Search by party name (year mandatory)
+
+```python
+import asyncio
+from bharat_courts import get_court, HCServicesClient
+
+
+async def main():
+    court = get_court("delhi")
+    async with HCServicesClient() as client:
+        cases = await client.case_status_by_party(
+            court,
+            party_name="state",
+            year="2024",            # mandatory — omitting it returns ERROR_VAL
+            status_filter="Both",   # "Pending", "Disposed", or "Both"
+        )
+        for c in cases:
+            print(f"{c.case_number}  {c.petitioner} vs {c.respondent}")
+            print(f"  status: {c.status}  next hearing: {c.next_hearing_date}")
+
+
+asyncio.run(main())
+```
+
+### Search by case number
+
+Use a case type code from `list_case_types` (here `134` is W.P.(C) in Delhi):
+
+```python
+import asyncio
+from bharat_courts import get_court, HCServicesClient
+
+
+async def main():
+    court = get_court("delhi")
+    async with HCServicesClient() as client:
+        cases = await client.case_status(
+            court,
+            case_type="134",
+            case_number="1",
+            year="2024",
+        )
+        for c in cases:
+            print(f"{c.case_number}  CNR={c.cnr_number}")
+            print(f"  {c.petitioner} vs {c.respondent}  status={c.status}")
+
+
+asyncio.run(main())
+```
+
+### Get court orders and download a PDF
+
+`court_orders` returns `CaseOrder` objects carrying the PDF URL. Download with
+`download_order_pdf` (no CAPTCHA — it reuses the same session):
+
+```python
+import asyncio
+from bharat_courts import get_court, HCServicesClient
+
+
+async def main():
+    court = get_court("delhi")
+    async with HCServicesClient() as client:
+        orders = await client.court_orders(
+            court,
+            case_type="134",
+            case_number="1",
+            year="2024",
+        )
+        for order in orders:
+            print(f"{order.order_date}  {order.judge}")
+            if order.pdf_url:
+                pdf = await client.download_order_pdf(order.pdf_url)
+                with open(f"order_{order.order_date}.pdf", "wb") as f:
+                    f.write(pdf)
+
+
+asyncio.run(main())
+```
+
+!!! note "Some order PDFs are not uploaded"
+
+    Even when a case exists, an individual order PDF may not have been uploaded to eCourts.
+    In that case `court_orders` still returns the URL, but `download_order_pdf` may raise
+    because the server doesn't return a valid PDF. Handle that per order.
+
+### Get the cause list
+
+The cause list is returned as one PDF per bench/judge. Pass `civil=False` for the criminal
+list, and a date in `DD-MM-YYYY` format (defaults to today if omitted):
+
+```python
+import asyncio
+from bharat_courts import get_court, HCServicesClient
+
+
+async def main():
+    court = get_court("delhi")
+    async with HCServicesClient() as client:
+        pdfs = await client.cause_list(
+            court,
+            civil=True,
+            causelist_date="24-06-2026",   # DD-MM-YYYY; omit for today
+        )
+        for entry in pdfs:
+            print(f"{entry.serial_number}  {entry.bench}  {entry.cause_list_type}")
+            print(f"  {entry.pdf_url}")
+
+
+asyncio.run(main())
+```
+
+## Notes and gotchas
+
+- **All methods are async** — call them with `await` inside an `asyncio.run(...)` entry point.
+- **Bench code** defaults to `"1"` (the principal bench). For courts with multiple benches
+  (e.g. Allahabad / Lucknow), pass the code from `list_benches` to the search methods.
+- **Case type codes are numeric and court-specific** — always discover them with
+  `list_case_types` rather than guessing.
+- **Rate limiting is built in** (1 second between requests by default). Tune it via
+  [configuration](../start/configuration.md).
+- **CAPTCHA accuracy** — the OCR solver is around 60% accurate per attempt, so the client
+  retries with fresh sessions; the occasional slow search is expected. See the
+  [CAPTCHA guide](captcha.md).
+
+## See also
+
+- [`Judgments` facade](facade.md) — the recommended default for finding judgments.
+- [CAPTCHA solvers](captcha.md) — OCR, ONNX, manual, and custom.
+- [Configuration](../start/configuration.md) — rate limits, timeouts, environment variables.
+- [Client reference](../reference/clients.md) — full signatures and model fields.

--- a/docs/guides/judgment-search.md
+++ b/docs/guides/judgment-search.md
@@ -1,0 +1,214 @@
+# Judgment Search Portal
+
+`JudgmentSearchClient` is the live client for **judgments.ecourts.gov.in** — the
+official eCourts portal that does **full-text keyword search** over High Court (and
+Supreme Court Reports) judgments. Give it a phrase or set of words and it returns
+matching judgments, each with a downloadable PDF.
+
+This is the only backend in bharat-courts that searches the *body* of a judgment.
+The historical archive can match on title and structured fields, but not on the
+words inside the text — so when a user says "find me judgments that *mention* X",
+this is the portal that can answer it.
+
+!!! note "Keyword search only — no party / CNR / case-number search here"
+    This portal supports **keyword / full-text search only**. There is no search by
+    party name, CNR, or case number on judgments.ecourts.gov.in. For those, use
+    `HCServicesClient` (High Courts) or `DistrictCourtClient` (district courts), or
+    look the judgment up in the archive by CNR. See
+    [High Courts](high-courts.md) and [District Courts](district-courts.md).
+
+!!! tip "Most callers should use the `Judgments` facade instead"
+    For the everyday "find a judgment matching X" question, prefer the federated
+    [`Judgments` facade](facade.md). It routes free-text queries to this portal for
+    you, folds in structured filters, and returns a uniform `Judgment` list — without
+    you having to reason about which backend to call. Reach for `JudgmentSearchClient`
+    directly when you specifically want portal-level control (page size, court type,
+    batch PDF downloads).
+
+## How it works
+
+The portal is CAPTCHA-gated. The client handles the whole dance for you:
+
+1. Establishes a session.
+2. Fetches the CAPTCHA image and solves it with the configured solver.
+3. Validates the CAPTCHA, receiving an `app_token` that must be echoed on every
+   subsequent request.
+4. Runs the search (a DataTables AJAX call) and parses the result rows.
+5. For each downloaded PDF, exchanges the row's path for a per-session download URL,
+   then fetches the bytes.
+
+The session token rotates on every call and the client tracks it automatically. If
+the session expires mid-pagination, `search_all()` re-authenticates and continues.
+
+!!! info "CAPTCHA solver required"
+    Like the other live clients, this one needs a CAPTCHA solver. With
+    `bharat-courts[ocr]` installed the default `OCRCaptchaSolver` (ddddocr) is used
+    automatically — no explicit solver argument needed. See [CAPTCHA handling](captcha.md).
+
+## Method reference
+
+| Method | CAPTCHA | Returns | Description |
+|---|---|---|---|
+| `search(search_text, *, page=1, page_size=10, search_opt="PHRASE", court_type="2", max_captcha_attempts=5)` | Yes | `SearchResult` | Search judgments by keyword (one page). |
+| `search_all(search_text, *, page_size=25, search_opt="PHRASE", court_type="2", max_captcha_attempts=5)` | Yes | `AsyncIterator[SearchResult]` | Paginate through every page; re-authenticates if the session token expires mid-walk. |
+| `download_pdf(judgment, *, court_type="2")` | No | `JudgmentResult` | Download the PDF for one result; sets `pdf_bytes` on the object in place. |
+| `download_pdfs(judgments, *, court_type="2", stop_on_error=False)` | No | `list[JudgmentResult]` | Batch download; skips results that already have `pdf_bytes`, logs failures unless `stop_on_error=True`. |
+
+### `search_opt` values
+
+| Value | Meaning |
+|---|---|
+| `"PHRASE"` | Match the words as an exact phrase (the default). |
+| `"ANY"` | Match judgments containing **any** of the words. |
+| `"ALL"` | Match judgments containing **all** of the words (any order). |
+
+### `court_type` values
+
+| Value | Meaning |
+|---|---|
+| `"2"` | High Courts (the default). |
+| `"3"` | Supreme Court Reports (SCR). |
+
+### What you get back
+
+`search()` and each page from `search_all()` return a `SearchResult`:
+
+| Field | Description |
+|---|---|
+| `items` | List of `JudgmentResult` for this page. |
+| `total_count` | Total matching judgments across all pages. |
+| `page` / `page_size` | Current page and rows per page. |
+| `has_next` / `total_pages` | Pagination helpers. |
+
+Each `JudgmentResult` carries `title`, `court_name`, `case_number`, `judgment_date`,
+`judges`, `citation`, `pdf_url`, `pdf_bytes`, `source_url`, `source_id`, and a
+`metadata` dict. After `download_pdf()`, `pdf_bytes` holds the PDF.
+
+## Single-page search
+
+```python
+import asyncio
+from bharat_courts import JudgmentSearchClient
+
+async def main():
+    async with JudgmentSearchClient() as client:
+        result = await client.search(
+            "right to privacy",
+            search_opt="ALL",   # match all of the words
+            court_type="2",     # High Courts
+            page_size=25,
+        )
+        print(f"{result.total_count} matches; showing {len(result.items)}")
+        for j in result.items:
+            print(f"{j.judgment_date}  {j.court_name}  {j.title}")
+
+asyncio.run(main())
+```
+
+## Paginate through every result
+
+`search_all()` is an async generator that yields one `SearchResult` per page and
+stops when there are no more rows. It transparently re-authenticates if the portal
+session expires during a long walk.
+
+```python
+import asyncio
+from bharat_courts import JudgmentSearchClient
+
+async def main():
+    async with JudgmentSearchClient() as client:
+        all_items = []
+        async for page in client.search_all(
+            "compassionate appointment",
+            search_opt="PHRASE",
+            page_size=50,
+        ):
+            print(f"page {page.page}/{page.total_pages}  (+{len(page.items)})")
+            all_items.extend(page.items)
+        print(f"collected {len(all_items)} judgments")
+
+asyncio.run(main())
+```
+
+!!! warning "Pagination burns CAPTCHA solves and hits a rate-limited portal"
+    Each search authenticates against a CAPTCHA, and the portal is rate-limited
+    (the client paces requests for you). Walking thousands of results can be slow
+    and may exhaust CAPTCHA retries. For large historical pulls, the
+    [archive](archive.md) (`ArchiveClient.iter_judgments`) is faster and imposes no
+    portal load — but note it can only match on title / structured fields, not on the
+    judgment body.
+
+## Download PDFs
+
+`download_pdf()` mutates the `JudgmentResult` in place, setting `pdf_bytes`. The
+row's `pdf_url` is a portal-internal path, not a directly fetchable URL — the client
+resolves it through the portal's download endpoint for you.
+
+```python
+import asyncio
+from bharat_courts import JudgmentSearchClient
+
+async def main():
+    async with JudgmentSearchClient() as client:
+        result = await client.search("medical negligence", search_opt="PHRASE")
+
+        # One PDF
+        first = await client.download_pdf(result.items[0])
+        with open("judgment.pdf", "wb") as f:
+            f.write(first.pdf_bytes)
+
+asyncio.run(main())
+```
+
+### Batch download
+
+`download_pdfs()` downloads PDFs for a list of results. It skips any result that
+already has `pdf_bytes`, and by default logs failures and keeps going (set
+`stop_on_error=True` to raise on the first failure instead).
+
+```python
+import asyncio
+from bharat_courts import JudgmentSearchClient
+
+async def main():
+    async with JudgmentSearchClient() as client:
+        result = await client.search("anticipatory bail", page_size=25)
+
+        downloaded = await client.download_pdfs(result.items)
+        for j in downloaded:
+            if j.pdf_bytes is not None:
+                print(f"{len(j.pdf_bytes):>8} bytes  {j.title}")
+            else:
+                print(f"   (no PDF)  {j.title}")
+
+asyncio.run(main())
+```
+
+!!! note "Some PDFs may be unavailable"
+    Not every judgment on the portal has an uploaded PDF, and the download path can
+    occasionally fail for a specific row. `download_pdfs()` skips and logs those by
+    default rather than aborting the whole batch.
+
+## Errors
+
+`search()` and `search_all()` raise `CaptchaError` if the solver cannot produce a
+valid CAPTCHA within `max_captcha_attempts` tries. An **empty** `SearchResult` is
+distinct from a failure: it means the portal genuinely returned zero matching rows.
+
+```python
+from bharat_courts.hcservices.parser import CaptchaError
+
+try:
+    result = await client.search("some rare phrase")
+except CaptchaError:
+    print("Could not get past the CAPTCHA; try again or use a different solver.")
+```
+
+## See also
+
+- [`Judgments` facade](facade.md) — the recommended entry point for judgment lookups;
+  routes free-text queries here for you.
+- [Historical archive](archive.md) — faster for bulk / historical pulls, but matches
+  on title and structured fields, not full text.
+- [CAPTCHA handling](captcha.md) — solvers used by all live clients.
+- [Clients API reference](../reference/clients.md) — full signatures.

--- a/docs/guides/supreme-court.md
+++ b/docs/guides/supreme-court.md
@@ -1,0 +1,157 @@
+# Supreme Court (`SCIClient`)
+
+`SCIClient` is the live client for the Supreme Court of India. It talks to the
+official portal at [www.sci.gov.in](https://www.sci.gov.in) and does two things
+reliably today:
+
+1. **`list_recent_judgments()`** — scrapes the homepage "Latest Judgements /
+   Orders" feed (the 50 most recent items), no CAPTCHA.
+2. **`download_pdf()`** — fetches the PDF bytes for one of those judgments.
+
+That is the whole live surface. Read the scope note below before you build on it.
+
+## Scope: what this client does and does not do
+
+!!! warning "Live SCI search is limited to the recent feed"
+    The legacy `main.sci.gov.in` host that used to serve year/party search has
+    been in long-term maintenance for years (every endpoint returns HTTP 503).
+    The current `www.sci.gov.in` site only exposes older judgments and
+    case-number search behind a CAPTCHA-protected form, and **that flow is not
+    wired up yet** in this SDK.
+
+    Concretely:
+
+    - `search_by_year(year, month=None)` raises `NotImplementedError`.
+    - `search_by_party(party_name)` raises `NotImplementedError`.
+
+    For anything beyond "the most recent ~50 SC judgments", use the
+    [historical archive](archive.md) (SCI 1950 to present) or the
+    [`Judgments` facade](facade.md).
+
+If you only need recent Supreme Court items — for a digest, a watch list, or a
+"what landed this week" check — `list_recent_judgments()` is exactly the right
+tool, and it needs no CAPTCHA and no credentials.
+
+## Quick example
+
+```python
+import asyncio
+from bharat_courts.sci import SCIClient
+
+
+async def main():
+    async with SCIClient() as client:
+        recent = await client.list_recent_judgments(limit=10)
+        for j in recent:
+            print(f"{j.judgment_date}  {j.case_number}  {j.title}")
+
+        # Download the PDF for the first item.
+        if recent:
+            j = await client.download_pdf(recent[0])
+            with open("sci_latest.pdf", "wb") as f:
+                f.write(j.pdf_bytes)
+
+asyncio.run(main())
+```
+
+`SCIClient` is an async context manager; `async with` opens and closes the
+underlying HTTP session for you.
+
+## Methods
+
+| Method | CAPTCHA | Returns | Description |
+|--------|---------|---------|-------------|
+| `list_recent_judgments(*, limit=50)` | No | `list[JudgmentResult]` | The homepage "Latest Judgements / Orders" feed. The portal caps this at 50; pass a smaller `limit` to truncate. |
+| `download_pdf(judgment)` | No | `JudgmentResult` | Downloads the PDF bytes for a judgment. Mutates the object in place: sets `pdf_bytes` on success. |
+| `search_by_year(year, month=None)` | — | — | **Not implemented** — raises `NotImplementedError`. Use the [archive](archive.md). |
+| `search_by_party(party_name)` | — | — | **Not implemented** — raises `NotImplementedError`. Use the [archive](archive.md). |
+
+### `list_recent_judgments(*, limit=50)`
+
+Scrapes the homepage feed of the 50 most recent items. `limit` is keyword-only
+and capped at 50 by the portal; passing a smaller value truncates the list
+locally. Returns a list of `JudgmentResult` objects.
+
+### `download_pdf(judgment)`
+
+Takes a `JudgmentResult` (typically one returned by `list_recent_judgments()`)
+and downloads its PDF. The judgment's `pdf_url` is the portal's
+`/sci-get-pdf/?diary_no=...` link that the in-page viewer iframe uses.
+
+- On success, the PDF bytes are stored on `judgment.pdf_bytes` and the same
+  object is returned.
+- If the judgment has no `pdf_url`, it raises `RuntimeError`.
+- If the response is not a valid PDF (it does not start with the `%PDF` magic
+  bytes), it raises `RuntimeError`.
+
+## What you get back: `JudgmentResult`
+
+Each item is a `JudgmentResult`. The fields most useful for the SCI feed:
+
+| Field | Meaning |
+|-------|---------|
+| `title` | Case title (e.g. petitioner vs. respondent) |
+| `case_number` | Case / diary number as shown on the portal |
+| `judgment_date` | Date of the judgment or order |
+| `judges` | Bench / authoring judges where available |
+| `pdf_url` | The `/sci-get-pdf/?diary_no=...` download link |
+| `pdf_bytes` | Populated by `download_pdf()` |
+| `source_url` | The portal page the item was scraped from |
+
+See the [models reference](../reference/models.md) for the full field list.
+
+## SCI live feed vs. the historical archive
+
+!!! info "Two different SCI sources — pick by recency"
+    There are **two** ways to get Supreme Court judgments in bharat-courts, and
+    they cover different windows:
+
+    - **`SCIClient` (this page)** — live scrape of the portal homepage. Only the
+      ~50 most recent items, but it is current to the minute and needs no
+      CAPTCHA. Use it for "the latest SC judgments".
+    - **[Historical archive](archive.md) (`ArchiveClient`)** — DuckDB queries
+      over the AWS Open Data bucket of SCI judgments from **1950 to present**,
+      with structured search by judge, year, party, citation, and CNR, plus
+      regional-language PDFs. No CAPTCHA, no rate limits. It lags the live
+      portal by roughly 2 months (bi-monthly updates), so the most recent
+      handful of judgments may not be there yet.
+
+    Rule of thumb: **last few weeks → `SCIClient`; everything older or any
+    structured/bulk search → the archive.**
+
+## When to reach for something else
+
+- **Structured SC search** ("all Justice Chandrachud judgments 2018–2024",
+  "judgments citing X") — use the [`Judgments` facade](facade.md), which routes
+  these to the archive automatically:
+
+    ```python
+    import asyncio
+    from bharat_courts import Judgments
+
+
+    async def main():
+        async with Judgments() as j:
+            results = await j.find(
+                court="sci", judge="chandrachud", year=(2018, 2024), limit=10,
+            )
+            for r in results:
+                print(f"{r.decision_date}  {r.case_id}  {r.title}")
+
+    asyncio.run(main())
+    ```
+
+- **A specific SC judgment by CNR** — `Judgments().find(cnr=...)` routes the CNR
+  prefix straight to the archive partition. SCI CNRs start with the `ESCR`
+  prefix.
+
+- **Full-text search across SC reports** — the
+  [judgment search portal](judgment-search.md) (`JudgmentSearchClient`) supports
+  keyword search with `court_type="3"` (Supreme Court Reports).
+
+## See also
+
+- [Historical archive guide](archive.md) — SCI 1950 to present, structured and bulk search.
+- [The `Judgments` facade](facade.md) — the recommended default entry point for finding any judgment.
+- [Judgment search portal](judgment-search.md) — keyword full-text search.
+- [Clients API reference](../reference/clients.md) — full signatures for `SCIClient` and the other live clients.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,12 @@
+---
+template: home.html
+title: bharat-courts — Indian court data, in the AI you already use
+description: >-
+  bharat-courts is a free, open-source skill that lets Claude, ChatGPT and your
+  own tools search cases, pull orders and read cause lists from India's courts —
+  700+ District Courts, 25 High Courts and the Supreme Court — straight from the
+  official record, on your machine, with no per-query fees.
+hide:
+  - navigation
+  - toc
+---

--- a/docs/lawyers/chatgpt-and-others.md
+++ b/docs/lawyers/chatgpt-and-others.md
@@ -1,0 +1,201 @@
+# Using bharat-courts with ChatGPT and Other AI Assistants
+
+You may already be working with ChatGPT, Gemini, Copilot, or another assistant
+and wonder whether bharat-courts can sit alongside them the way it does with
+Claude. The honest answer: yes, but the experience is different, and it pays to
+know exactly what works where before you start.
+
+This page is candid about the trade-offs. The smoothest, no-setup-in-the-chat
+experience today is with Claude. Everywhere else, the realistic, working path is
+to use bharat-courts as a **tool** — through its command line or its Python
+library — and hand the results to your assistant.
+
+!!! info "What works where, at a glance"
+
+    | Assistant | How it connects to bharat-courts | Setup effort |
+    |---|---|---|
+    | **Claude Code** (terminal) | Bundled Agent Skill — ask in plain English | One command |
+    | **Claude Desktop / Claude.ai** | Agent Skill | A few clicks |
+    | **ChatGPT, Gemini, Copilot, others** | Run the CLI or Python yourself, feed the output to the chat | Manual, but reliable |
+    | Any tool that can run local scripts | Wire the CLI/Python in as a custom tool | Depends on the tool |
+
+    There is **no official ChatGPT plugin** and **no MCP server** for
+    bharat-courts. The plain-English "skill" mechanism is built for Claude. We
+    would rather tell you that plainly than have you hunt for an integration
+    that does not exist.
+
+## Why Claude is the easy path (and the others are not)
+
+bharat-courts ships an **Agent Skill** — a small instruction file the SDK can
+install into Claude with one command:
+
+```bash
+bharat-courts install-skills
+```
+
+That file teaches Claude how to call the library, handle CAPTCHAs, and pick the
+right data source. Once installed, you ask questions in ordinary English and
+Claude does the work. See [Claude Code](claude-code.md) and
+[Claude Desktop](claude-desktop.md) for the full walkthroughs.
+
+Skills are a Claude feature. ChatGPT, Gemini, and other assistants do not read
+that skill file, so the same "just ask" experience is not available there yet.
+That does not mean they are shut out — it means you connect them a different
+way.
+
+## The honest, working pattern for ChatGPT and others
+
+bharat-courts is plain Python plus a command-line tool that prints **clean
+JSON**. Any assistant that can either run code or accept pasted data can use it.
+There are two practical shapes:
+
+1. **Run a command, paste the result into the chat.** Works with every
+   assistant, no integration needed.
+2. **Let the assistant run the code.** Works where the assistant has a code
+   sandbox or can call a local tool you define.
+
+### Pattern 1 — run the CLI, feed the JSON to your assistant
+
+Every CLI command accepts a global `--json` flag and prints structured JSON to
+standard output. You run the command in your terminal, then paste the JSON into
+ChatGPT (or any chat) and ask it to summarise, compare, or draft from it.
+
+Find a judgment across the archive and the live portals:
+
+```bash
+bharat-courts find --text "right to privacy" --json
+```
+
+Search a High Court by party name (note: the registration year is mandatory):
+
+```bash
+bharat-courts hcservices search-by-party delhi --party "state" --year 2024 --json
+```
+
+Query the historical archive by judge and year range (no CAPTCHA, no rate
+limits):
+
+```bash
+bharat-courts archive query --court sci --judge "chandrachud" --year 2018-2024 --json
+```
+
+Each prints a JSON array you can paste straight into your chat. A typical
+exchange:
+
+```text
+You:   Here is JSON from a court-data tool. Summarise these judgments in a
+       table — case title, court, decision date, outcome — and flag any that
+       look like they involve a public-sector bank.
+
+       [paste the JSON output here]
+
+ChatGPT: <reads the structured data and answers>
+```
+
+Because the output is real data the library fetched, the assistant is
+summarising facts you pulled, not guessing. That is the key benefit of this
+route — you keep the AI well away from inventing case details.
+
+!!! tip "Save the output to a file for longer results"
+
+    Wide party-name searches can return many records. Redirect the JSON to a
+    file and either upload it to your assistant or open it beside the chat:
+
+    ```bash
+    bharat-courts find --judge "nariman" --court sci --year 2019 --json > results.json
+    ```
+
+    ChatGPT, Gemini, and similar tools can all read an uploaded `.json` file.
+
+If you are new to the command line, the full command list, flags, and download
+options live in the [CLI guide](../guides/cli.md).
+
+### Pattern 2 — let the assistant run the code
+
+If your assistant has a code-execution sandbox (for example, ChatGPT's data
+analysis / code interpreter) **and** that sandbox has internet access and the
+package installed, it can run bharat-courts directly. The library is ordinary
+async Python:
+
+```python
+import asyncio
+from bharat_courts import Judgments
+
+async def main():
+    async with Judgments() as j:
+        results = await j.find(judge="chandrachud", year=(2018, 2024),
+                               court="sci", limit=10)
+        for r in results:
+            print(r.decision_date, r.case_id, r.title)
+
+asyncio.run(main())
+```
+
+!!! warning "Sandbox limits are real"
+
+    Many hosted code sandboxes have **no outbound internet access**. The live
+    eCourts portals and the AWS archive both require network calls, so a locked
+    sandbox cannot reach them. When that is the case, fall back to Pattern 1:
+    run the command on your own machine and paste the JSON in. Treat Pattern 2
+    as a bonus where it happens to work, not a guarantee.
+
+### Pattern 3 — wire it in as a custom tool (for builders)
+
+If you are building an agent or a function-calling setup — or your assistant
+supports running local scripts or custom tools — you can register bharat-courts
+as one of its tools. The natural wrapper is the federated `find` entry point:
+
+```python
+import asyncio
+from bharat_courts import Judgments
+
+async def find_indian_judgments(text=None, judge=None, court=None,
+                                year=None, cnr=None, limit=10):
+    """Tool: find Indian court judgments (archive + live eCourts)."""
+    async with Judgments() as j:
+        results = await j.find(text=text, judge=judge, court=court,
+                               year=year, cnr=cnr, limit=limit)
+        return [r.to_dict(exclude_none=True) for r in results]
+```
+
+Expose that function to your framework's tool/function-calling interface and the
+model can call it with structured arguments. Every result is a dataclass with
+`to_dict()` and `to_json()`, so it serialises cleanly into a tool response.
+
+!!! info "\"Any MCP-compatible assistant\" — read this carefully"
+
+    bharat-courts does **not** ship an MCP server. But MCP, and similar
+    local-tool mechanisms, exist precisely so you can wrap a script as a tool
+    your assistant calls. If your assistant supports running local tools, you
+    can wire bharat-courts in yourself using the function pattern above. We are
+    describing a path you can build, not a shipped, supported integration.
+
+## A note on accuracy, cost, and privacy
+
+These hold regardless of which assistant you use:
+
+- **The data is real.** bharat-courts fetches from the official eCourts portals
+  and the public AWS Open Data archive. When you feed its JSON to an assistant,
+  the assistant is working from fetched records, not its training memory — which
+  is exactly what you want for anything case-specific.
+- **No bharat-courts subscription or API key.** The library is free and
+  open-source. The archive needs no account at all. You may still pay your AI
+  provider (for example, ChatGPT) separately for their service.
+- **You control where data goes.** With Pattern 1 you decide what to paste into
+  the chat. Sensitive matter details never leave your machine unless you choose
+  to share them.
+
+## Which route should I pick?
+
+- **You want the least friction and plain-English questions** → use
+  [Claude Code](claude-code.md) or [Claude Desktop](claude-desktop.md).
+- **You are committed to ChatGPT or another assistant** → run the
+  [CLI](../guides/cli.md) with `--json` and paste the results in (Pattern 1).
+  This is the most reliable route everywhere.
+- **You are building software around an assistant** → wrap
+  `Judgments().find(...)` as a tool (Pattern 3) and start from the
+  [Quickstart](../start/quickstart.md).
+
+Whichever you choose, the engine underneath is the same: one library covering
+25+ High Courts, 700+ District Courts, the Supreme Court, and a historical
+archive going back to 1950.

--- a/docs/lawyers/claude-code.md
+++ b/docs/lawyers/claude-code.md
@@ -1,0 +1,150 @@
+# Set up bharat-courts in Claude Code
+
+If you work in Claude Code (or Claude CoWork), this is the most reliable way to
+give Claude access to Indian court data. It takes one command. After that, you
+simply ask for what you need in plain English — Claude figures out which court,
+which portal, and how to fetch the answer.
+
+This page walks you through it end to end. No prior coding knowledge is assumed.
+
+!!! info "What you're setting up"
+    bharat-courts ships an **Agent Skill** — a small bundle of instructions that
+    teaches Claude how to use the library. The `bharat-courts install-skills`
+    command copies that bundle into a folder Claude Code already watches
+    (`.claude/skills/`). Claude discovers it automatically; there is nothing else
+    to switch on.
+
+## Step 1 — Install bharat-courts
+
+You need Python 3.11 or newer. In a terminal, install the package with the two
+extras that make it most capable for legal work:
+
+```bash
+pip install "bharat-courts[ocr,archive]"
+```
+
+- `ocr` adds automatic CAPTCHA solving, so Claude can read the live eCourts
+  portals (case status, orders, cause lists) without you typing in those
+  squiggly codes by hand.
+- `archive` adds the historical research archive — Supreme Court judgments back
+  to 1950 and 25 High Courts, with no CAPTCHA and no rate limits.
+
+!!! tip "Why both extras"
+    With both installed, Claude can answer current-status questions *and*
+    historical-research questions, and it picks the right source for each query
+    on its own. If you only ever need one side, you can install just `[ocr]` or
+    just `[archive]` — the skill works with whatever is available.
+
+For more on the install options (including the `[all]` bundle and the ONNX
+CAPTCHA solver), see the [Installation guide](../start/installation.md).
+
+## Step 2 — Install the skill into your project
+
+Move into the folder where you do your work — your matter folder, a research
+directory, anywhere you'll be chatting with Claude Code — and run:
+
+```bash
+bharat-courts install-skills
+```
+
+You'll see exactly this confirmation:
+
+```text
+Skills installed to `.claude/skills/bharat-courts`.
+```
+
+That's it. The command copied the skill bundle into a hidden `.claude/skills/`
+folder inside your current directory.
+
+!!! note "What just happened"
+    `install-skills` writes the skill files into
+    `.claude/skills/bharat-courts/` relative to wherever you ran the command.
+    Run it once per project folder where you want court-data access. If you
+    work across several matter folders, run it in each one (or run it at the
+    top level of a workspace that contains them).
+
+## Step 3 — Just ask
+
+Claude Code automatically discovers any skill placed under `.claude/skills/`.
+Open Claude Code in that folder and ask for what you need in everyday language.
+For example:
+
+> Find all pending writ petitions for Tata Motors in the Delhi High Court from 2024.
+
+> Pull every Supreme Court judgment authored by Justice Chandrachud between 2018 and 2024 and list the case numbers.
+
+> What's on the cause list for the Karnataka High Court tomorrow?
+
+> Download the latest orders in WPA 12886 of 2024 before the Calcutta High Court.
+
+> Show me the most recent Supreme Court judgments and save the PDFs.
+
+Claude reads the skill, decides whether the answer lives in the live portals or
+the historical archive, handles the CAPTCHA and session details, and returns the
+result. You stay in plain English the whole way.
+
+For a much larger, copy-paste-ready set of example prompts grouped by task, see
+[Example prompts for lawyers](prompts.md).
+
+!!! tip "Accuracy and freshness"
+    The historical archive lags live court records by about two to three months.
+    If you ask about something decided very recently and Claude comes back empty
+    from the archive, ask it to "check the live portal instead" — the skill knows
+    to fall back, and Claude will tell you when it does.
+
+## Claude CoWork
+
+Claude CoWork uses the **same skill bundle**. There is no separate package and no
+different file — it is the identical `.claude/skills/bharat-courts/` bundle that
+`install-skills` produces.
+
+The only difference is *how* CoWork picks the bundle up. Add it the way CoWork
+loads Agent Skills, then ask in natural language exactly as you would in Claude
+Code. The precise menus and steps for adding a skill are owned by Anthropic and
+can change, so rather than guess at labels here, follow the official guide:
+
+- [Anthropic Agent Skills documentation](https://docs.anthropic.com/en/docs/agents-and-tools/agent-skills/overview)
+
+Once CoWork sees the skill, every example prompt on this page works unchanged.
+
+!!! note "It's the same mechanism everywhere"
+    Claude Code, Claude CoWork, and other Claude surfaces that support Agent
+    Skills all consume the one bundle produced by `bharat-courts install-skills`.
+    Install once, use anywhere Claude reads skills.
+
+## For engineers: skip the skill if you prefer
+
+!!! tip "You can call the library directly"
+    The Agent Skill is a convenience layer over a normal Python SDK and CLI. If
+    you're building tooling or scripting bulk work, you don't need Claude in the
+    loop at all — call the SDK or the `bharat-courts` command yourself.
+
+    - The [CLI guide](../guides/cli.md) covers commands like
+      `bharat-courts find`, `bharat-courts hcservices search`, and
+      `bharat-courts archive query`.
+    - The [federated facade guide](../guides/facade.md) covers the
+      `Judgments().find(...)` entry point that routes between the live portals
+      and the archive for you.
+
+## Troubleshooting
+
+??? note "The confirmation line didn't appear"
+    If you see `Skill source directory not found.` instead, the install of the
+    package itself didn't complete. Re-run Step 1, then `bharat-courts
+    install-skills` again.
+
+??? note "Claude isn't using the skill"
+    Make sure you ran `install-skills` *inside* the folder you have open in
+    Claude Code, and that a `.claude/skills/bharat-courts/` folder now exists
+    there. Skills are discovered per project directory.
+
+??? note "CAPTCHA or live-portal questions fail"
+    Confirm you installed the `ocr` extra (Step 1). Without it, the live eCourts
+    portals can't be read automatically. The historical archive still works
+    without `ocr`.
+
+## Where to next
+
+- [Example prompts for lawyers](prompts.md) — a deeper library of ready-to-use questions.
+- [Installation guide](../start/installation.md) — all install options explained.
+- [CLI guide](../guides/cli.md) — drive bharat-courts from the command line.

--- a/docs/lawyers/claude-desktop.md
+++ b/docs/lawyers/claude-desktop.md
@@ -1,0 +1,162 @@
+# Set up bharat-courts in Claude Desktop
+
+This page walks you through giving Claude Desktop the ability to look up Indian
+court data for you — case status, orders, cause lists, and judgments going back
+to 1950 — so you can ask in plain English and get real answers pulled from the
+official eCourts portals and the public judgment archive.
+
+You do not need to be a programmer. There are four short steps. Set it up once
+and it keeps working.
+
+!!! info "What you are actually installing"
+    bharat-courts ships an **Agent Skill** — a small folder of instructions that
+    teaches Claude how and when to use the tool. There is no separate plugin,
+    no account to create, and no API key. Claude runs the bharat-courts
+    software on your own computer when you ask it a court-data question.
+
+---
+
+## Step 1 — Install Python and the package
+
+Claude Desktop needs the bharat-courts software present on your computer so it
+can actually run searches. This is a one-time install.
+
+!!! note "Prerequisite: Python 3.11 or newer"
+    bharat-courts requires **Python 3.11+**. If you do not already have it,
+    download it from [python.org](https://www.python.org/downloads/) and run the
+    installer. On the first screen of the Windows installer, tick
+    **"Add Python to PATH"** before clicking Install.
+
+Once Python is installed, open a terminal (Terminal on macOS, Command Prompt or
+PowerShell on Windows) and run:
+
+```bash
+pip install "bharat-courts[ocr,archive]"
+```
+
+The two extras in the brackets are what make the assistant genuinely useful:
+
+| Extra | What it adds | Why it matters to you |
+|---|---|---|
+| `ocr` | Automatic CAPTCHA solving (the `ddddocr` engine) | The live eCourts portals are CAPTCHA-gated. With this, Claude solves them for you — no typing in squiggly letters by hand. |
+| `archive` | Historical archive support (DuckDB over the public AWS Open Data buckets) | Lets Claude search Supreme Court judgments from 1950 onward and 25 High Courts instantly, with no CAPTCHA and no rate limits. |
+
+Installing both gives Claude access to **live** court data (current status,
+cause lists, in-progress orders) *and* the **historical archive** (past
+judgments, bulk research). That is the recommended setup.
+
+!!! tip "If the command is not found"
+    On some systems the command is `pip3` instead of `pip`, or
+    `python3 -m pip install "bharat-courts[ocr,archive]"`. If none work, Python
+    was likely not added to PATH during install — re-run the Python installer
+    and make sure that box is ticked.
+
+---
+
+## Step 2 — Generate the skill folder
+
+bharat-courts can write its skill folder for you. In the same terminal, navigate
+to a folder you can find again (your home folder is fine) and run:
+
+```bash
+bharat-courts install-skills
+```
+
+This copies the skill into a folder named:
+
+```text
+.claude/skills/bharat-courts/
+```
+
+(created inside whatever directory you ran the command from). The command prints
+the exact location it wrote to — note it down, you will point Claude Desktop at
+this folder in the next step.
+
+??? note "Prefer to use the folder shipped inside the package?"
+    The skill also lives inside the installed package itself, at
+    `bharat_courts/skill/` within your Python environment. Running
+    `install-skills` is the simplest way to get a clean, easy-to-find copy, so
+    we recommend that over hunting for the bundled folder.
+
+---
+
+## Step 3 — Add the skill in Claude Desktop
+
+Claude Desktop loads Agent Skills from its settings. Because Anthropic refines
+the Desktop interface from time to time, we will describe this in general terms
+rather than naming exact buttons that may change.
+
+1. Open **Claude Desktop** and go into its **Settings**.
+2. Find the area for **Skills** (sometimes presented under Capabilities).
+3. **Add** a skill and point it at the `bharat-courts` skill folder you created
+   in Step 2 (the `.claude/skills/bharat-courts/` folder).
+4. Make sure the skill is **enabled**.
+
+!!! info "Follow Anthropic's current instructions for the exact clicks"
+    The precise menu names and the location of the Skills setting can change
+    between Claude Desktop versions. For the up-to-date, step-by-step
+    walkthrough straight from the vendor, see Anthropic's official Agent Skills
+    documentation at [docs.anthropic.com](https://docs.anthropic.com) and the
+    help centre at [support.anthropic.com](https://support.anthropic.com).
+
+---
+
+## Step 4 — Verify it works
+
+Start a new chat in Claude Desktop and ask a simple question, for example:
+
+> "Using bharat-courts, list the most recent Supreme Court judgments."
+
+If everything is wired up, Claude will recognise the bharat-courts skill, run it,
+and come back with real results rather than saying it cannot access court data.
+
+!!! tip "A good first test"
+    The recent Supreme Court feed is the easiest thing to verify because it
+    needs no CAPTCHA and no case details — just a clean check that the skill is
+    connected. Once that works, move on to the things you actually need every
+    day.
+
+For dozens of ready-to-paste, plain-English prompts — finding a client's pending
+matters, pulling orders, checking tomorrow's cause list, researching past
+judgments — see the [example prompts page](prompts.md).
+
+---
+
+## Troubleshooting
+
+??? question "Claude says it cannot find the tool, or the skill does nothing"
+    The most common cause is that bharat-courts is installed in a *different*
+    Python environment from the one Claude Desktop uses. Make sure you ran the
+    `pip install "bharat-courts[ocr,archive]"` command in the same Python that
+    is on your system PATH. Re-running that install command and then restarting
+    Claude Desktop usually resolves it. Also confirm the skill is enabled in
+    Settings and that you pointed it at the `.claude/skills/bharat-courts/`
+    folder (not its parent).
+
+??? question "I see CAPTCHA errors when Claude searches the live portals"
+    The live eCourts portals are protected by CAPTCHAs. Automatic solving comes
+    from the `ocr` extra — if you installed plain `bharat-courts` without it,
+    re-run:
+
+    ```bash
+    pip install "bharat-courts[ocr]"
+    ```
+
+    CAPTCHA solving is automatic but not perfect; the tool retries with fresh
+    attempts, so an occasional miss is normal and usually clears on a retry.
+
+??? question "Historical / older judgment searches return nothing"
+    Make sure the `archive` extra is installed (`pip install "bharat-courts[archive]"`).
+    Also note the archive lags real time by a couple of months — for a judgment
+    delivered in the last 2–3 months, ask Claude to check the **live** portal
+    instead.
+
+---
+
+## Prefer Claude Code?
+
+If you work in a terminal or a code editor, the setup is even quicker and uses
+the same skill folder. See [Set up in Claude Code](claude-code.md).
+
+For the full installation reference, including every available extra, see
+[Installation](../start/installation.md).

--- a/docs/lawyers/faq.md
+++ b/docs/lawyers/faq.md
@@ -1,0 +1,142 @@
+# Frequently Asked Questions
+
+Straight answers to the questions lawyers ask before they start using bharat-courts.
+Short version: it is free, the data comes straight from official sources, and your
+client's information never passes through us.
+
+### Is it free?
+
+Yes. bharat-courts is open-source software released under the MIT licence. There is no
+subscription, no per-query fee, and no account to register for the tool itself.
+
+The only thing you pay for is your own AI assistant subscription — for example your
+Claude or ChatGPT plan — if you choose to use bharat-courts through an AI agent. That
+is a payment to the AI vendor for their assistant, not to us. If you use the Python SDK
+or the command line directly, there is nothing to pay at all.
+
+!!! info "What about court fees?"
+    bharat-courts only reads what the eCourts portals and the public archive already
+    publish for free. It does not pay or charge any court fee.
+
+### Where does the data come from?
+
+Two complementary sources, both official or officially-released:
+
+- **Live data** comes directly from the official eCourts portals —
+  hcservices.ecourts.gov.in, services.ecourts.gov.in, judgments.ecourts.gov.in, the
+  Supreme Court site (www.sci.gov.in), and the Calcutta High Court's own website. This
+  is the same data you would see if you visited those sites yourself.
+- **Historical judgments** come from the public AWS Open Data buckets maintained by
+  Dattam Labs (Supreme Court from 1950 onwards, plus 25 High Courts). This archive is
+  released under the CC-BY-4.0 licence.
+
+When you reuse or republish material from the archive, attribute **Dattam Labs / the
+eCourts platform** as the source.
+
+See [About → Data sources](../about/data-sources.md) for the full breakdown.
+
+### Can I rely on it in court?
+
+bharat-courts fetches data *from* the official record — it does not generate or alter
+case information. That makes it an excellent research and tracking aid.
+
+That said, treat any answer an AI assistant gives you as a **research aid, not the final
+word**. For anything mission-critical — a citation you will put before a judge, a
+limitation date, the exact text of an order — verify it against the official record
+(the certified copy, the portal itself, or the downloaded PDF) before you rely on it.
+bharat-courts is software, not legal advice.
+
+!!! warning "Verify the important things"
+    AI assistants can misread or summarise loosely. For dates, citations and operative
+    findings, open the actual PDF that bharat-courts downloads for you and read it.
+
+### Is my client's data private?
+
+Yes. Queries run **from your own machine straight to the official source**. There is no
+bharat-courts server sitting in the middle, and nothing is routed through a paid data
+vendor who could log or resell your searches.
+
+The party names, case numbers and CNRs you look up go directly to the eCourts portals or
+the public archive — exactly as if you typed them into the portal in your browser. If
+you use an AI assistant, that assistant's vendor processes your prompt under their own
+privacy terms; the court data itself still travels machine-to-source.
+
+### How fresh is the data?
+
+It depends on which source answers your question:
+
+- **Live portals** reflect the **current** state — case status, today's and tomorrow's
+  cause lists, recently uploaded orders. This is as fresh as the official portal.
+- **The historical archive lags by roughly 2–3 months.** The Supreme Court bucket
+  updates bi-monthly and the High Court buckets update quarterly.
+
+In practice: for a matter decided in the last couple of months, or for "what is the
+status right now", the live portals are the right source. For older judgments and bulk
+research, the archive is faster and has no CAPTCHA.
+
+!!! tip "If a recent judgment isn't found"
+    If a search of the archive turns up nothing for a very recent year, it may simply
+    not be in the archive yet. Ask your assistant to check the live portal instead.
+
+### What is a CAPTCHA, and why might I see errors?
+
+The live eCourts portals protect their search forms with a CAPTCHA — the distorted
+characters you normally type in by hand. bharat-courts can solve these automatically:
+with the optional OCR add-on installed, it reads the CAPTCHA for you and retries with a
+fresh attempt if the first read is wrong (in our measurements it succeeds the large
+majority of the time, with automatic retries to cover the rest).
+
+So you will usually never see a CAPTCHA at all. Occasionally a search may fail after
+several attempts, or a portal may be slow or temporarily down — in that case, simply
+ask again. The historical archive has **no CAPTCHA**, so archive queries never hit this.
+
+See [Guides → CAPTCHA handling](../guides/captcha.md) for the technical detail.
+
+### Which courts are covered?
+
+- The **Supreme Court of India**
+- **25 High Courts** (every High Court, including bench-specific entries for Bombay and
+  Allahabad)
+- **700+ District Courts** across all 36 states and union territories
+
+Plus the historical archive (Supreme Court from 1950 and 25 High Courts). For the exact
+list of courts, codes and what each source can and can't do, see
+[About → Data sources](../about/data-sources.md).
+
+### Do I need to be technical?
+
+No — not for everyday use. If you use Claude with the bharat-courts skill installed, you
+simply ask questions in plain English and the assistant does the rest. There is a small
+one-time setup to get it running.
+
+- Setting it up with Claude (no coding): [For lawyers → Claude Desktop](claude-desktop.md)
+  and [Claude Code](claude-code.md).
+- Using other AI tools: [ChatGPT and others](chatgpt-and-others.md).
+- Ready-to-paste example questions: [Prompts that work](prompts.md).
+
+If you are (or have) an engineer, the [Installation](../start/installation.md) and
+[Quickstart](../start/quickstart.md) pages cover the Python SDK and command line.
+
+### What can't it do yet?
+
+We would rather be honest than oversell. Current limitations:
+
+- **Full-text "find any case mentioning X" searches use the live judgments portal**,
+  which is CAPTCHA-gated and rate-limited, so they are slower than structured searches
+  against the archive. Use specific filters (court, year, judge) where you can.
+- **Supreme Court live access is a recent-judgments feed only.** bharat-courts can pull
+  the Supreme Court's latest published judgments and download those PDFs, but search by
+  case number or party name on the SCI site is not wired up yet. For historical SCI
+  judgments, use the archive instead.
+- **Some order PDFs may simply not be uploaded by the court.** When that happens
+  bharat-courts can still show you that the order exists, but the download will fail
+  because the court never published the file.
+- **Live case status is limited to what the search results return.** Fields like next
+  hearing date, sitting judges and disposal status live behind a separate case-history
+  page that the tool does not yet read, so they may come back blank.
+
+### Where do I start?
+
+- New to AI assistants: [For lawyers — overview](index.md).
+- Want examples to copy: [Prompts that work](prompts.md).
+- Building on top of it: [Quickstart](../start/quickstart.md).

--- a/docs/lawyers/index.md
+++ b/docs/lawyers/index.md
@@ -1,0 +1,104 @@
+# bharat-courts for Lawyers
+
+**bharat-courts gives the AI assistant you already use — Claude, and other tools — live and historical access to the official Indian court record.** Instead of logging into clunky eCourts portals, solving CAPTCHAs by hand, and copy-pasting case details one row at a time, you simply ask in plain English: *"What's the next hearing in my Bombay High Court writ petition?"* or *"Find me Supreme Court judgments on the right to privacy."* The assistant reaches straight into the eCourts platform and the public judgment archive, does the tedious clicking for you, and hands back the answer.
+
+It is free, open-source, and runs on your own machine. There is no new subscription, no third-party legal database to pay for, and your queries stay on your computer.
+
+!!! info "Who this section is for"
+    These pages are written for practising lawyers and their teams — no coding required. If you build legal-tech and want the Python SDK and API signatures, head to the [engineer guides](../guides/facade.md) and the [API reference](../reference/index.md) instead.
+
+## What it can do for you
+
+Think of it as a research clerk that never sleeps and never loses a session to a CAPTCHA.
+
+### Track your matters and check case status
+
+Look up any case by case number, party name, or advocate across **25+ High Courts**, **700+ District Courts**, and the Supreme Court. Pull up the parties, the CNR number, the case type, and the filing details in seconds.
+
+> *"Find all matters for Reliance Industries in the Delhi High Court filed in 2024."*
+
+> *"Look up writ petition W.P.(C) 4520 of 2023 in the Bombay High Court."*
+
+!!! note "An honest note on live status"
+    The eCourts case-search endpoint the tool reads returns the parties, case number and CNR, but **not** a live "Pending / Disposed" flag or the next-hearing date — those sit behind a separate case-history page the library does not yet read. For the most reliable picture of where a matter stands today, treat the tool as your fast first look and confirm the live status detail on the portal.
+
+### See the daily cause lists
+
+Find out which cases are listed before which bench, on any given day, without refreshing the portal all morning.
+
+> *"Download the civil cause list for the Delhi High Court for tomorrow."*
+
+> *"What's listed before the District & Sessions Judge at Patna Sadar on 20 March?"*
+
+### Pull order and judgment PDFs
+
+Get the PDFs of orders and judgments in a matter with a single request — saved straight to a file you can read or forward.
+
+> *"Download every order in this Calcutta High Court WPA from 2024."*
+
+> *"Get me the latest order PDF in this case and summarise it."*
+
+### Search 75 years of judgments and precedent
+
+Behind the live portals sits a historical archive of **Supreme Court judgments from 1950 onwards and 25 High Courts** — a public, openly-licensed dataset (CC-BY-4.0) hosted on AWS Open Data. It carries no CAPTCHA and no rate limits, so precedent research is fast.
+
+> *"Find judgments authored by Justice Chandrachud in the Supreme Court between 2018 and 2024."*
+
+> *"Show me all Delhi High Court judgments from 2020 mentioning Tata."*
+
+!!! tip "One question, the right source"
+    You never have to decide whether your question needs the live portal or the historical archive. The library's `find` routing picks the right backend for you — a CNR or a precedent search goes to the fast archive; a free-text body search goes to the live portal — and tells you which source each result came from.
+
+## Why it's different
+
+!!! info "Free and open-source"
+    bharat-courts is released under the MIT licence. There is no per-seat fee, no usage cap, and no expensive commercial database in the middle. You pay nothing to use it.
+
+!!! info "Runs locally — your work stays confidential"
+    The tool runs on your own computer. Your searches — client names, case numbers, the matters you are researching — are sent only to the official court systems they query, not to any bharat-courts server. There isn't one.
+
+!!! info "Straight from the official source"
+    Results come directly from the eCourts platform (`hcservices.ecourts.gov.in`, `services.ecourts.gov.in`, `judgments.ecourts.gov.in`), the Supreme Court's own site, the Calcutta High Court website, and the government-affiliated AWS Open Data judgment archive. You are reading the court record, not a re-keyed third-party copy.
+
+!!! warning "Where it is honest about its limits"
+    The historical archive lags real time by roughly **2–3 months** (it refreshes bi-monthly for the Supreme Court and quarterly for the High Courts), so a judgment delivered last week may only be reachable via the live portal. Automated CAPTCHA solving is good but not perfect, so the occasional live lookup needs a retry — the library handles those retries for you. When something is unavailable or stale, the assistant should say so rather than guess.
+
+## Get set up in minutes
+
+Pick the assistant you already use. Each guide walks you through installation and your first query in plain English.
+
+<div class="grid cards" markdown>
+
+-   :material-monitor:{ .lg .middle } __[Use it in Claude Desktop](claude-desktop.md)__
+
+    ---
+
+    The simplest path for most lawyers. Install the app, add the bharat-courts
+    skill, and ask away — no terminal required for day-to-day use.
+
+-   :material-console:{ .lg .middle } __[Use it in Claude Code](claude-code.md)__
+
+    ---
+
+    For the command line. Run `bharat-courts install-skills` once and Claude Code
+    can look up cases and judgments for you in any project.
+
+-   :material-robot-outline:{ .lg .middle } __[ChatGPT and other assistants](chatgpt-and-others.md)__
+
+    ---
+
+    Not on Claude? You can still use bharat-courts as a tool the honest way —
+    through its Python command-line interface. Here's how.
+
+-   :material-comment-text-multiple:{ .lg .middle } __[Example prompts to copy](prompts.md)__
+
+    ---
+
+    A ready-to-use library of plain-English prompts for case status, cause lists,
+    order PDFs, and precedent research — grouped by what you need.
+
+</div>
+
+## Next step
+
+Most lawyers should start with **[Claude Desktop](claude-desktop.md)** — it's the gentlest setup. Once it's connected, open the **[example prompts](prompts.md)** and try one against a matter you're working on today. If you hit a snag or want to know more about accuracy, cost, and privacy, the **[FAQ](faq.md)** answers the questions lawyers ask most.

--- a/docs/lawyers/prompts.md
+++ b/docs/lawyers/prompts.md
@@ -1,0 +1,264 @@
+# What You Can Ask
+
+This is your prompt playbook. Once bharat-courts is installed into your AI assistant
+(see [Claude Desktop](claude-desktop.md) or [Claude Code](claude-code.md)), you can ask
+for Indian court data in plain English — no case-citation format to memorise, no portal
+to navigate, no CAPTCHAs to squint at.
+
+Below are the everyday tasks lawyers do most, each with example prompts you can copy,
+adapt, and type straight into the chat. A short note under each group tells you what
+comes back.
+
+!!! tip "How to read this page"
+    The prompts are written the way a real person would type them. You do not need exact
+    case numbers or codes — the assistant figures out the right court and the right lookup
+    from what you describe. The more specific you are (court, year, party name), the
+    faster and tighter the answer.
+
+---
+
+## 1. Case status and next hearing
+
+Find a matter and see where it stands — across the High Courts and the 700+ District
+Courts on the eCourts platform. You can search by **party name**, by **case number**, or
+by **CNR** (the 16-character Case Number Record that uniquely identifies every case).
+
+```text
+Find all cases for Reliance Industries in the Delhi High Court filed in 2024.
+```
+
+```text
+Look up W.P.(C) 4520 of 2023 in the Bombay High Court and show me the case details.
+```
+
+```text
+What's the CNR and the parties for case number 100 of 2024 in the Patna district court, Patna Sadar?
+```
+
+```text
+Pull up the case with CNR DLHC010230802020.
+```
+
+```text
+Search for matters where State of Bihar is a party in the Patna District Court in 2024.
+```
+
+**What comes back:** the matched cases with case number, case type (e.g. "W.P.(C)"),
+the petitioner and respondent, the court name, and the CNR. You can then ask follow-ups
+like "now get me the orders in that one" (see section 3).
+
+!!! note "A note on live status fields"
+    The eCourts case-lookup returns the parties, case number, and CNR reliably. Fields
+    like the current Pending/Disposed status, the next hearing date, and the judges are
+    *not* part of that quick lookup — they sit behind a separate case-history page the
+    tool does not read yet. For the authoritative current status of a live matter, treat
+    the result as a starting point and confirm on the official portal or the case file.
+
+For the engineering detail behind these lookups, see the
+[High Courts guide](../guides/high-courts.md) and the
+[District Courts guide](../guides/district-courts.md).
+
+---
+
+## 2. The daily cause list
+
+See which cases are listed before which bench, for today or any date you name — for
+both High Courts and District Courts.
+
+```text
+What's on the civil cause list for the Delhi High Court tomorrow?
+```
+
+```text
+Get me the criminal cause list for the Karnataka High Court for 15 January 2025.
+```
+
+```text
+Download the cause list PDF for the Principal Bench of the Bombay High Court today.
+```
+
+```text
+Show me the District & Sessions Court cause list for Patna Sadar for 20 March 2026.
+```
+
+**What comes back:** for High Courts, the list of benches sitting that day with a
+downloadable cause-list PDF per bench. For District Courts, structured entries —
+serial number, case number, parties, advocates, and the court number — for the date and
+court you asked about.
+
+!!! info "Dates"
+    If you don't name a date, you get today's list. Dates are interpreted as
+    DD-MM-YYYY internally, but you can just say "tomorrow" or "15 January 2025" and the
+    assistant will translate.
+
+---
+
+## 3. Orders and judgments in a specific case
+
+List every order passed in a case — and download the PDFs.
+
+```text
+List all the orders in W.P.(C) 4520 of 2023 before the Bombay High Court and download each PDF.
+```
+
+```text
+Get me the latest order in case number 1 of 2024 in the Delhi High Court.
+```
+
+```text
+Find the orders in WPA 12886 of 2024 in the Calcutta High Court (appellate side) and save the judgments.
+```
+
+```text
+Download all judgments in case number 100 of 2024 from the Patna district court.
+```
+
+**What comes back:** each order with its date, type ("Order", "Interim Order",
+"Judgment"), the judge, and a link to the PDF — which the assistant can download and save
+to a file for you.
+
+!!! tip "Calcutta High Court has its own door"
+    For Calcutta HC matters from September 2020 onwards, the tool can search the court's
+    own website directly, which often has better PDF coverage and includes the neutral
+    citation (e.g. `2024:CHC-AS:1277`). Just mention Calcutta and the side
+    (appellate, original, Jalpaiguri, or Port Blair). See the
+    [Calcutta HC guide](../guides/calcutta-hc.md).
+
+!!! warning "Some PDFs are not uploaded"
+    Even when a case exists, an individual order PDF may simply not have been uploaded to
+    eCourts yet. The tool will give you the case and the order list; if a specific PDF
+    isn't available, that's a gap on the portal, not an error on your end.
+
+---
+
+## 4. Precedent and research across the historical archive
+
+This is where bharat-courts shines for research. It can query a complete historical
+archive of judgments — the **Supreme Court from 1950 to the present, plus 25 High Courts**
+— with no CAPTCHA and no rate limits. Search by judge, by year or year range, by citation,
+or by keyword in the title.
+
+```text
+Find judgments authored by Justice Chandrachud in the Supreme Court between 2018 and 2024.
+```
+
+```text
+Show me Delhi High Court judgments from 2020 whose title mentions Tata.
+```
+
+```text
+Find Supreme Court judgments citing AIR 1973 — pull the citation and the outcome.
+```
+
+```text
+Get me the PDF of the judgment with CNR DLHC010230802020.
+```
+
+```text
+Find Supreme Court right-to-privacy judgments and download the Hindi-language versions.
+```
+
+**What comes back:** the matched judgments with decision date, case ID, title, citation,
+and disposal outcome — and the assistant can fetch the full PDF for any of them. Supreme
+Court judgments are also available in regional languages (Hindi, Tamil, Gujarat, and more);
+High Court archive PDFs are English-only.
+
+!!! note "Keyword search: title vs. full text"
+    The historical archive matches keywords against the **case title and metadata**, not
+    the full body of the judgment. For a true full-text search across the body of High
+    Court judgments — "every case that mentions 'right to privacy' anywhere in the text" —
+    the tool uses the live eCourts judgment-search portal instead. You can simply ask in
+    plain English; the assistant picks the right source for you.
+
+See the [Archive guide](../guides/archive.md) and the
+[Judgment Search guide](../guides/judgment-search.md) for the full picture.
+
+---
+
+## 5. Recent Supreme Court judgments feed
+
+Stay on top of what the Supreme Court has just delivered.
+
+```text
+Show me the 10 most recent Supreme Court judgments.
+```
+
+```text
+What has the Supreme Court delivered this week? Download the PDFs.
+```
+
+```text
+List the latest Supreme Court orders and tell me which are judgments vs. orders.
+```
+
+**What comes back:** the most recent items from the Supreme Court's official "Latest
+Judgements / Orders" feed (up to 50) — each with the parties, case number, diary number,
+decision date, and a downloadable PDF. No CAPTCHA needed for this one.
+
+!!! info "Searching the Supreme Court by case or party"
+    The recent-judgments feed is the supported way to pull fresh SCI items. Searching the
+    Supreme Court by a specific case number or party name through the live portal is not
+    wired up yet — for older SCI matters, use the historical archive (section 4), which
+    goes back to 1950.
+
+See the [Supreme Court guide](../guides/supreme-court.md).
+
+---
+
+## 6. Bulk and research-scale pulls
+
+For power users — chambers running large research projects, legal-tech teams, or anyone
+building a dataset — the tool can stream judgments at scale.
+
+```text
+Stream every Delhi High Court judgment from 2020 — there are around 18,000 — and save them.
+```
+
+```text
+Count how many Supreme Court judgments were decided in 1975.
+```
+
+```text
+Pull all judgments by a given judge across a five-year range and export them to a spreadsheet.
+```
+
+**What comes back:** results streamed in batches rather than all at once, so even
+tens-of-thousands-of-row pulls stay manageable. Every result can be exported to JSON for
+a spreadsheet, dashboard, or case-management tool.
+
+!!! tip "This is genuinely fast"
+    Because the archive is read directly from public data buckets, bulk pulls run in
+    seconds with no portal load and no CAPTCHA — unlike the live portals, which are
+    rate-limited and CAPTCHA-gated. If you're doing research at scale, ask for the
+    archive. Engineers can see the streaming API in the
+    [Archive guide](../guides/archive.md).
+
+---
+
+## Two honest limitations worth knowing
+
+These aren't problems with the tool so much as facts about the underlying data. Keeping
+them in mind will save you a surprise.
+
+!!! tip "1. Freshness — the archive lags a couple of months"
+    The historical archive is refreshed periodically (Supreme Court roughly every two
+    months, High Courts roughly quarterly), so a judgment delivered in the **last 2–3
+    months** may not be in it yet. When you ask about a very recent matter, the assistant
+    will reach for the **live portals** instead. If a recent search comes back empty,
+    just say "check the live portal too" — that's the right next move.
+
+!!! tip "2. Always verify anything mission-critical"
+    bharat-courts fetches data *from* the official eCourts and Supreme Court sources — it
+    doesn't make anything up. But AI output is a powerful **research aid, not legal
+    advice**. For anything that decides a filing, a limitation date, or a client's
+    position, confirm the result against the official record or the case file before you
+    rely on it.
+
+---
+
+## Where to go next
+
+- New to all this? Start with [Using bharat-courts in Claude](claude-desktop.md).
+- Questions about cost, privacy, and accuracy? See the [FAQ](faq.md).
+- An engineer on your team wants the API? Point them at the
+  [guides](../guides/facade.md).

--- a/docs/reference/archive.md
+++ b/docs/reference/archive.md
@@ -1,0 +1,6 @@
+# Archive client
+
+DuckDB-backed access to the public AWS Open Data judgment buckets. Requires the
+`[archive]` extra. See the [archive guide](../guides/archive.md) for context.
+
+::: bharat_courts.archive.client.ArchiveClient

--- a/docs/reference/captcha.md
+++ b/docs/reference/captcha.md
@@ -1,0 +1,21 @@
+# CAPTCHA solvers
+
+The live portals are Securimage-CAPTCHA gated. Solving is pluggable: implement the
+`CaptchaSolver` ABC, or use one of the bundled solvers. See the
+[CAPTCHA guide](../guides/captcha.md).
+
+## CaptchaSolver (base class)
+
+::: bharat_courts.captcha.base.CaptchaSolver
+
+## OCRCaptchaSolver
+
+::: bharat_courts.captcha.ocr.OCRCaptchaSolver
+
+## ONNXCaptchaSolver
+
+::: bharat_courts.captcha.onnx.ONNXCaptchaSolver
+
+## ManualCaptchaSolver
+
+::: bharat_courts.captcha.manual.ManualCaptchaSolver

--- a/docs/reference/clients.md
+++ b/docs/reference/clients.md
@@ -1,0 +1,24 @@
+# Live clients
+
+Portal scrapers for the official eCourts and court websites. All are async
+context managers and accept a pluggable [`CaptchaSolver`](captcha.md).
+
+## HCServicesClient
+
+::: bharat_courts.hcservices.client.HCServicesClient
+
+## DistrictCourtClient
+
+::: bharat_courts.districtcourts.client.DistrictCourtClient
+
+## JudgmentSearchClient
+
+::: bharat_courts.judgments.client.JudgmentSearchClient
+
+## CalcuttaHCClient
+
+::: bharat_courts.calcuttahc.client.CalcuttaHCClient
+
+## SCIClient
+
+::: bharat_courts.sci.client.SCIClient

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1,0 +1,7 @@
+# Configuration
+
+Settings are read once into a module-level `config` singleton, with environment
+overrides under the `BHARAT_COURTS_` prefix. See the
+[configuration guide](../start/configuration.md) for the full list of variables.
+
+::: bharat_courts.config.BharatCourtsConfig

--- a/docs/reference/courts.md
+++ b/docs/reference/courts.md
@@ -1,0 +1,16 @@
+# Courts registry
+
+The static registry of every supported court and the helpers for resolving them
+by code, name, eCourts state code, or CNR prefix.
+
+::: bharat_courts.courts
+    options:
+      members:
+        - get_court
+        - get_court_by_name
+        - get_court_by_state_code
+        - infer_court_from_cnr
+        - list_all_courts
+        - list_high_courts
+        - ALL_COURTS
+        - SUPREME_COURT

--- a/docs/reference/facade.md
+++ b/docs/reference/facade.md
@@ -1,0 +1,12 @@
+# Judgments facade
+
+The recommended default entry point. See the [facade guide](../guides/facade.md)
+for the routing rules and worked examples.
+
+## Judgments
+
+::: bharat_courts.facade.Judgments
+
+## live_to_judgment
+
+::: bharat_courts.facade.live_to_judgment

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,54 @@
+# API Reference
+
+Auto-generated from the source docstrings. This is the canonical, always-in-sync
+reference for the `bharat_courts` package — every signature, parameter and return
+type below is extracted directly from the code.
+
+New to the library? Start with the [Quickstart](../start/quickstart.md) and the
+[guides](../guides/facade.md), which show these APIs in context.
+
+<div class="grid cards" markdown>
+
+-   :material-magnify-scan:{ .lg .middle } __[Judgments facade](facade.md)__
+
+    ---
+
+    `Judgments` — the federated entry point. One `find()` call, routed to the
+    right backend automatically.
+
+-   :material-server-network:{ .lg .middle } __[Live clients](clients.md)__
+
+    ---
+
+    `HCServicesClient`, `DistrictCourtClient`, `JudgmentSearchClient`,
+    `CalcuttaHCClient`, `SCIClient` — the portal scrapers.
+
+-   :material-database-search:{ .lg .middle } __[Archive client](archive.md)__
+
+    ---
+
+    `ArchiveClient` — DuckDB queries over the AWS Open Data buckets, plus PDF
+    retrieval and caching.
+
+-   :material-shape:{ .lg .middle } __[Data models](models.md)__
+
+    ---
+
+    `Judgment`, `CaseInfo`, `CaseOrder`, `CauseListPDF`, `SearchResult` and the
+    rest of the typed DTOs.
+
+-   :material-bank:{ .lg .middle } __[Courts registry](courts.md)__
+
+    ---
+
+    `get_court`, `infer_court_from_cnr` and the static registry of every
+    supported court.
+
+-   :material-robot:{ .lg .middle } __[CAPTCHA solvers](captcha.md)__
+
+    ---
+
+    The pluggable `CaptchaSolver` ABC and its OCR / ONNX / manual
+    implementations.
+
+</div>

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -1,0 +1,18 @@
+# Data models
+
+Every result type is a plain dataclass with a `to_dict()` / `to_json()` mixin, so
+results serialise straight to JSON for spreadsheets, dashboards or case-management
+tools.
+
+::: bharat_courts.models
+    options:
+      members:
+        - Judgment
+        - JudgmentResult
+        - CaseInfo
+        - CaseOrder
+        - CauseListPDF
+        - CauseListEntry
+        - SearchResult
+        - Court
+        - CourtType

--- a/docs/start/configuration.md
+++ b/docs/start/configuration.md
@@ -1,0 +1,141 @@
+# Configuration
+
+bharat-courts reads its settings from a single configuration object,
+`BharatCourtsConfig`, defined in `src/bharat_courts/config.py`. It is built on
+[pydantic-settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/),
+which means every field can be overridden from an **environment variable** or a
+**`.env` file** — no code changes required.
+
+All variables share the prefix `BHARAT_COURTS_`. So the field `timeout` is set
+with the environment variable `BHARAT_COURTS_TIMEOUT`.
+
+!!! info "The defaults are sensible"
+    You do not need to configure anything to get started. The values below are
+    only worth changing if you are scraping unusually wide queries, running
+    behind a proxy, or want quieter (or louder) logging.
+
+## Settings reference
+
+These are the only settings on `BharatCourtsConfig`. Each one is a plain Python
+attribute with a default; the matching environment variable is the prefix plus
+the upper-cased field name.
+
+| Setting | Env var | Default | What it does |
+|---|---|---|---|
+| `request_delay` | `BHARAT_COURTS_REQUEST_DELAY` | `1.0` | Seconds to wait between requests to a court portal. Polite rate limiting so the SDK does not hammer the eCourts servers. |
+| `user_agent` | `BHARAT_COURTS_USER_AGENT` | a Chrome-on-macOS string | The `User-Agent` header sent with every request. The portals expect a browser-like agent; override only if you have a specific reason. |
+| `timeout` | `BHARAT_COURTS_TIMEOUT` | `60` | HTTP request timeout, in seconds. Wide District Court party-name searches genuinely take 30–60s on the portal, so the default is deliberately generous. |
+| `max_retries` | `BHARAT_COURTS_MAX_RETRIES` | `3` | How many times a failed HTTP request is retried before giving up. |
+| `log_level` | `BHARAT_COURTS_LOG_LEVEL` | `"INFO"` | Logging verbosity (`"DEBUG"`, `"INFO"`, `"WARNING"`, `"ERROR"`). Routing decisions in the `Judgments` facade are logged at `INFO`. |
+
+!!! note "These settings drive the live portal clients"
+    `request_delay`, `timeout`, and `max_retries` apply to the rate-limited
+    HTTP client used by the live eCourts clients (`HCServicesClient`,
+    `DistrictCourtClient`, `JudgmentSearchClient`, and friends). The archive
+    backend talks to plain S3 and does not need rate limiting, so it is not
+    governed by `request_delay`.
+
+## Setting values
+
+### Option 1 — environment variables
+
+Export the variables in your shell before running your script or the CLI:
+
+```bash
+export BHARAT_COURTS_TIMEOUT=120
+export BHARAT_COURTS_REQUEST_DELAY=2.0
+export BHARAT_COURTS_LOG_LEVEL=DEBUG
+
+python my_search.py
+```
+
+This is the right approach for CI pipelines, containers, and one-off runs.
+
+### Option 2 — a `.env` file
+
+pydantic-settings automatically loads a file named `.env` from the current
+working directory. Create one next to your script:
+
+```text
+BHARAT_COURTS_TIMEOUT=120
+BHARAT_COURTS_REQUEST_DELAY=2.0
+BHARAT_COURTS_LOG_LEVEL=DEBUG
+```
+
+No extra code is needed — when `bharat_courts` is imported, the config object
+picks the file up.
+
+!!! tip "Keep `.env` out of version control"
+    A `.env` file is convenient for local development, but add it to your
+    `.gitignore` so machine-specific settings (and anything sensitive you add
+    later) do not get committed.
+
+## How the config is loaded
+
+The module exposes a single, module-level config object that is constructed
+**once**, at import time:
+
+```python
+# bharat_courts/config.py
+config = BharatCourtsConfig()
+```
+
+Every live client falls back to this shared `config` singleton when you do not
+pass one explicitly. If you want per-client settings, build your own instance
+and hand it in:
+
+```python
+import asyncio
+from bharat_courts import HCServicesClient
+from bharat_courts.config import BharatCourtsConfig
+
+async def main():
+    cfg = BharatCourtsConfig(timeout=120, request_delay=2.0)
+    async with HCServicesClient(config=cfg) as client:
+        ...
+
+asyncio.run(main())
+```
+
+!!! warning "Because the singleton is built at import time, set env vars first"
+    The `config` object reads the environment when `bharat_courts` is first
+    imported. Set your environment variables (or write your `.env` file)
+    **before** importing the package, otherwise the change will not be picked
+    up for the default singleton. Passing an explicit `BharatCourtsConfig(...)`
+    to a client always works regardless of import order.
+
+!!! warning "`0` is a legal value — do not collapse it with `or`"
+    When you read a numeric setting in your own code, do not write
+    `value = arg or DEFAULT`. In Python, `bool(0)` is `False`, so `0 or DEFAULT`
+    silently becomes `DEFAULT` — turning a deliberate `0` (e.g. "no delay")
+    into the default. Use an explicit `None` check instead:
+
+    ```python
+    value = arg if arg is not None else DEFAULT
+    ```
+
+    This bit the SDK once with a `ttl_seconds=0` argument; it is worth keeping
+    in mind whenever a `0` is meaningful.
+
+## Archive cache settings
+
+The opt-in [archive backend](../guides/archive.md) caches downloaded parquet
+metadata and judgment PDFs under `~/.cache/bharat-courts/archive/`. These cache
+controls are **not** part of `BharatCourtsConfig` — they are read directly by
+the archive module — but they are still environment variables, so they belong
+in the same `.env` file:
+
+| Env var | Default | What it does |
+|---|---|---|
+| `BHARAT_COURTS_ARCHIVE_CACHE_MAX_GB` | `5` | Maximum size of the on-disk archive cache, in GiB. The cache uses LRU eviction once it exceeds this cap. |
+| `BHARAT_COURTS_ARCHIVE_METADATA_TTL_DAYS` | `30` | How long mirrored parquet metadata shards are considered fresh before they are re-fetched from S3. |
+
+You can also set the cache directory and size limit directly when constructing
+an `ArchiveClient` via its `cache_dir` and `cache_max_bytes` arguments — see the
+[archive guide](../guides/archive.md).
+
+## See also
+
+- [Installation](installation.md) — extras (`[ocr]`, `[archive]`, `[cli]`, `[all]`) and Python version.
+- [Quickstart](quickstart.md) — your first search in a few lines.
+- [Config API reference](../reference/config.md) — the auto-generated `BharatCourtsConfig` class reference.

--- a/docs/start/installation.md
+++ b/docs/start/installation.md
@@ -1,0 +1,159 @@
+# Installation
+
+`bharat-courts` is a regular Python package — install it with `pip` from PyPI. The base
+package is small (an async HTTP stack and a few parsers); the heavier capabilities (CAPTCHA
+solving, the historical archive) are opt-in **extras** so you only install what you need.
+
+## Requirements
+
+- **Python 3.11 or newer** (3.11 and 3.12 are tested and supported).
+- A working `pip`. If your system Python is older than 3.11, install `python3.12` and run
+  `python3.12 -m pip ...` in the commands below.
+
+!!! tip "Use a virtual environment"
+    Keep the install isolated from your system Python:
+
+    ```bash
+    python3.12 -m venv .venv
+    source .venv/bin/activate    # Windows: .venv\Scripts\activate
+    pip install bharat-courts
+    ```
+
+## Base install
+
+```bash
+pip install bharat-courts
+```
+
+This gives you the SDK and every client class — `Judgments`, `HCServicesClient`,
+`DistrictCourtClient`, `JudgmentSearchClient`, `SCIClient`, `CalcuttaHCClient`, and
+`ArchiveClient` — plus the court registry and data models. It pulls in `httpx`,
+`pydantic-settings`, `beautifulsoup4`, and `lxml`.
+
+What the base install does **not** include: automatic CAPTCHA solving, the historical
+archive (DuckDB), and the command-line tool. Each is an extra, described below.
+
+## Optional extras
+
+Extras are added in square brackets after the package name. You can combine them with commas,
+e.g. `pip install "bharat-courts[ocr,archive]"`.
+
+| Extra | Command | What it enables |
+|---|---|---|
+| `ocr` | `pip install "bharat-courts[ocr]"` | Automatic CAPTCHA solving via `ddddocr` (+ `Pillow`). **Recommended** for the live eCourts portals. |
+| `archive` | `pip install "bharat-courts[archive]"` | The historical archive (`ArchiveClient`) — DuckDB queries against the public AWS Open Data buckets. |
+| `onnx` | `pip install "bharat-courts[onnx]"` | An alternative ONNX-based CAPTCHA solver (`onnxruntime` + `numpy` + `Pillow`). Needs `HF_TOKEN` — see the note below. |
+| `cli` | `pip install "bharat-courts[cli]"` | The `bharat-courts` command-line tool (`click` + `rich`). |
+| `all` | `pip install "bharat-courts[all]"` | Everything above plus the dev/test tooling (`pytest`, `respx`, `ruff`). |
+
+!!! info "Why CAPTCHA solving is an extra"
+    The official eCourts portals gate searches behind image CAPTCHAs. The live clients
+    (`HCServicesClient`, `DistrictCourtClient`, `JudgmentSearchClient`, `CalcuttaHCClient`)
+    need a CAPTCHA solver to run unattended. Install `[ocr]` and the clients auto-detect and
+    use `ddddocr` with no extra configuration. The archive (`ArchiveClient`) and the Supreme
+    Court feed (`SCIClient`) are CAPTCHA-free and work on the base install.
+
+## Recommended: `[ocr,archive]`
+
+For most users — and especially anyone using the `Judgments` facade — install both the OCR and
+archive extras:
+
+=== "pip"
+
+    ```bash
+    pip install "bharat-courts[ocr,archive]"
+    ```
+
+=== "uv"
+
+    ```bash
+    uv pip install "bharat-courts[ocr,archive]"
+    ```
+
+The [`Judgments` facade](../guides/facade.md) is the recommended entry point for "find a
+judgment matching X". It owns both backends and routes each query to the right one:
+
+- **structured filters** (judge, party, year, court, citation) and **CNR lookups** go to the
+  **archive** — fast, no CAPTCHA, no rate limits. This needs `[archive]`.
+- **free-text** searches go to the **live** judgments portal, which is the only backend that
+  does full-body text search. This needs a CAPTCHA solver, i.e. `[ocr]`.
+
+Install only one extra and the facade still works, but it can only use the backend you have.
+Installing both lets it pick the best route for every query.
+
+## The ONNX CAPTCHA solver
+
+`[onnx]` provides `ONNXCaptchaSolver`, a lighter alternative to `ddddocr`. Most users should
+prefer `[ocr]`; reach for ONNX only if you have a specific reason.
+
+!!! note "ONNX requires a Hugging Face token"
+    The ONNX model is hosted on Hugging Face and download requires authentication. Set the
+    `HF_TOKEN` environment variable before using `ONNXCaptchaSolver`:
+
+    ```bash
+    export HF_TOKEN=hf_...        # get a token at https://huggingface.co/settings/tokens
+    ```
+
+    Without a valid `HF_TOKEN` the model download fails. If you just want auto-solving that
+    works out of the box, use `[ocr]` instead — it has no auth requirement.
+
+See [CAPTCHA handling](../guides/captcha.md) for how to choose and configure a solver, including
+the manual (stdin) solver and writing your own.
+
+## The command-line tool
+
+Installing `[cli]` (or `[all]`) registers the `bharat-courts` command, backed by `click` and
+`rich`. Verify it:
+
+```bash
+bharat-courts --help
+```
+
+See the [CLI guide](../guides/cli.md) for the available commands.
+
+## Installing the AI-agent skill
+
+`bharat-courts` ships a Claude **Agent Skill** so you can ask your AI assistant for court data
+in plain English instead of writing code. Once the package is installed (with `[cli]` or
+`[all]`), copy the skill into your project:
+
+```bash
+bharat-courts install-skills
+```
+
+This writes the skill into `.claude/skills/bharat-courts/`, after which Claude can use the SDK
+on your behalf. For a non-technical, step-by-step setup, see the lawyer-facing guides:
+
+- [Using bharat-courts in Claude Desktop](../lawyers/claude-desktop.md)
+- [Using bharat-courts in Claude Code](../lawyers/claude-code.md)
+- [ChatGPT and other assistants](../lawyers/chatgpt-and-others.md)
+
+!!! note "Claude-native skill"
+    The skill is a Claude Agent Skill (a `SKILL.md` definition). There is no MCP server and no
+    ChatGPT plugin. For non-Claude tools, the honest path is to use the Python SDK or CLI as a
+    tool the assistant can call.
+
+## Verify your install
+
+A quick check that the package imports and the registry loads:
+
+```python
+import asyncio
+from bharat_courts import Judgments, get_court
+
+async def main():
+    print(get_court("delhi"))          # Court(name="Delhi High Court", ...)
+    async with Judgments() as j:
+        results = await j.find(cnr="DLHC010230802020")
+        print(f"{len(results)} result(s)")
+
+asyncio.run(main())
+```
+
+If that runs, you're ready to go.
+
+## Next steps
+
+- [Quickstart](quickstart.md) — your first real searches and PDF downloads.
+- [Configuration](configuration.md) — cache locations, rate limits, and environment variables.
+- [The `Judgments` facade](../guides/facade.md) — the recommended way to find judgments.

--- a/docs/start/quickstart.md
+++ b/docs/start/quickstart.md
@@ -1,0 +1,158 @@
+# Quickstart
+
+The fastest path to a result is the federated `Judgments` facade. You describe the
+judgment you want — by judge, year, court, free text, or CNR — and the SDK picks the
+right backend (the historical AWS archive or the live eCourts portal), runs the query,
+and hands back a uniform list of `Judgment` objects.
+
+If you have not installed the library yet, see [Installation](installation.md). For the
+facade to use both backends, install both extras:
+
+```bash
+pip install 'bharat-courts[archive,ocr]'
+```
+
+!!! tip "Lawyers: you may not need any code at all"
+    If you are a practising lawyer, the easiest way to use bharat-courts is through your
+    AI assistant. Install the bundled skill once and then ask questions in plain English —
+    no Python required. See the [guide for lawyers](../lawyers/index.md).
+
+## One entry point: `Judgments`
+
+```python
+import asyncio
+from bharat_courts import Judgments
+
+async def main():
+    async with Judgments() as j:
+        # 1. Structured filters → archive (no CAPTCHA, partition-pruned)
+        results = await j.find(judge="chandrachud", year=(2018, 2024), court="sci", limit=10)
+        for r in results:
+            print(f"{r.decision_date}  {r.case_id}  {r.title}  [{r.source}]")
+
+        # 2. Free text → live (only the live portal does full-body search)
+        for r in await j.find(text="right to privacy", limit=5):
+            print(f"{r.decision_date}  {r.title}  [{r.source}]")
+
+        # 3. CNR alone → archive (the 4-letter prefix routes to the right bucket)
+        hits = await j.find(cnr="DLHC010230802020")
+        if hits:
+            pdf_bytes = await j.fetch_pdf(hits[0])
+            with open("judgment.pdf", "wb") as f:
+                f.write(pdf_bytes)
+
+asyncio.run(main())
+```
+
+Three things to notice:
+
+- **`find()` is the only call you make.** You never decide between archive and live —
+  the facade reads the shape of your query and routes for you.
+- **Every result is a `Judgment`** with the same fields regardless of where it came from
+  (`decision_date`, `title`, `case_id`, `citation`, `judges`, `disposal_nature`, and more).
+- **`r.source`** is `"archive"` or `"live"` on each item, so you can always tell which
+  backend answered.
+
+!!! info "PDFs for live results"
+    `fetch_pdf()` works for archive judgments and for CNR strings whose prefix maps to a
+    known court. It raises `NotImplementedError` for a live `Judgment` (the live download
+    needs the original session-bound search result). For those, call
+    `JudgmentSearchClient.download_pdf(...)` directly — see
+    [Judgment search](../guides/judgment-search.md).
+
+## How `find()` routes
+
+In the default `source="auto"` mode, the facade picks a backend from the filters you pass:
+
+| What you pass | Backend | Why |
+|---|---|---|
+| `cnr=` set | archive | The 4-letter CNR prefix resolves to a court and partition — no scan |
+| `text=` only | live | Only the live judgments portal does full-body text search |
+| structured only (`judge`, `party`, `year`, `court`, `citation`) | archive | Partition-pruned, no CAPTCHA, no rate limits |
+| `text=` + structured | archive | `text` folds into a title-substring match (the `party` slot) |
+| nothing | — | raises `ValueError` — give at least one filter |
+
+You can override the choice with `source="archive"` or `source="live"`:
+
+```python
+# Force the live portal — e.g. for a case decided in the last few weeks
+recent = await j.find(text="bail", source="live", limit=5)
+```
+
+!!! note "Freshness gap"
+    The archive lags the courts by a few months (SCI updates bi-monthly, High Courts
+    quarterly). If a structured query returns nothing for a very recent year, retry with
+    `source="live"` or use the live clients directly.
+
+### `find()` parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `text` | `str \| None` | Free-text keyword search. Routes to live on its own. |
+| `court` | `Court \| str \| None` | Court object or code (`"sci"`, `"delhi"`, …). |
+| `year` | `int \| tuple[int, int] \| None` | Single year or inclusive range. Strongly recommended for non-CNR queries. |
+| `judge` | `str \| None` | Substring on the judge field (archive). |
+| `party` | `str \| None` | Substring on petitioner/respondent (SCI) or title (HC). |
+| `citation` | `str \| None` | Citation substring (archive, SCI only). |
+| `cnr` | `str \| None` | Exact CNR. Auto-routes via the prefix in `auto` mode. |
+| `source` | `"auto" \| "archive" \| "live"` | Override automatic routing. Default `"auto"`. |
+| `limit` | `int` | Total results to return. Default `50`. |
+
+The routing decision is logged at INFO under `logging.getLogger("bharat_courts.facade")`,
+so it is easy to confirm what happened in production.
+
+## The same thing from the command line
+
+The CLI mirrors `find()`. The `--json` flag is global, so it goes **before** the
+subcommand. Install the CLI with `pip install 'bharat-courts[cli]'` (or `[all]`).
+
+```bash
+# Structured: judge + year range + court
+bharat-courts find --judge chandrachud --year 2018-2024 --court sci --limit 10
+
+# Free text (routes to live)
+bharat-courts find --text "right to privacy" --limit 5
+
+# CNR (routes to archive via the prefix)
+bharat-courts find --cnr DLHC010230802020
+
+# Force a backend
+bharat-courts find --text bail --source live --limit 5
+
+# Machine-readable output — note --json comes before `find`
+bharat-courts --json find --cnr DLHC010230802020
+```
+
+`--year` accepts a single year (`2020`) or a hyphenated range (`2018-2024`). The default
+`--limit` for the CLI is `20`. The full command reference is in the
+[CLI guide](../guides/cli.md).
+
+## Next steps
+
+<div class="grid cards" markdown>
+
+-   :material-source-branch: __The facade in depth__
+
+    Routing internals, forcing a backend, and combining text with structured filters.
+
+    [:octicons-arrow-right-24: Federated facade](../guides/facade.md)
+
+-   :material-bank: __High Courts__
+
+    Case status, orders, and cause lists across 25+ High Courts via `HCServicesClient`.
+
+    [:octicons-arrow-right-24: High Courts](../guides/high-courts.md)
+
+-   :material-database-search: __Historical archive__
+
+    Bulk streaming, PDF retrieval, and the AWS Open Data buckets (1950–present).
+
+    [:octicons-arrow-right-24: Archive](../guides/archive.md)
+
+-   :material-console: __Command line__
+
+    Every subcommand, global flags, and JSON output for scripting.
+
+    [:octicons-arrow-right-24: CLI](../guides/cli.md)
+
+</div>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,81 @@
+/* ============================================================
+   bharat-courts — global theme tokens (applies to all doc pages)
+   Custom indigo palette layered on Material's "custom" primary/accent.
+   ============================================================ */
+
+:root {
+  --md-primary-fg-color:        #0b0b12;
+  --md-primary-fg-color--light: #1a1a28;
+  --md-primary-fg-color--dark:  #060609;
+  --md-primary-bg-color:        #ffffff;
+  --md-primary-bg-color--light: rgba(255, 255, 255, 0.72);
+
+  --md-accent-fg-color:         #5b5bd6;
+  --md-accent-fg-color--transparent: rgba(91, 91, 214, 0.12);
+
+  --md-typeset-a-color:         #5048c4;
+}
+
+[data-md-color-scheme="slate"] {
+  --md-hue: 250;
+  --md-default-bg-color:        #0d0d14;
+  --md-accent-fg-color:         #8d8df3;
+  --md-typeset-a-color:         #9b9bf5;
+  --md-primary-fg-color:        #0b0b12;
+}
+
+/* Typographic roles — serif display (Fraunces) for the top headings + brand,
+   Inter for body/UI (theme default), JetBrains Mono for code (theme default). */
+:root { --bc-display: "Fraunces", "Iowan Old Style", Georgia, serif; }
+
+.md-typeset h1,
+.md-typeset h2 {
+  font-family: var(--bc-display);
+  font-weight: 600;
+  letter-spacing: -0.015em;
+}
+.md-typeset h1 { font-weight: 600; }
+/* h3+ stay in Inter for scannable, technical subheadings */
+.md-typeset h3,
+.md-typeset h4 { letter-spacing: -0.01em; font-weight: 700; }
+
+/* Brand wordmark in the header uses the display serif */
+.md-header__title,
+.md-header__topic .md-ellipsis { font-family: var(--bc-display); font-weight: 600; font-size: 1.05rem; }
+
+/* mkdocstrings symbol headings are code-y identifiers — keep them mono, not serif */
+.md-typeset h1 code,
+.md-typeset h2 code,
+.doc-heading code { font-family: var(--md-code-font, monospace); }
+.doc-heading { font-family: var(--md-code-font, monospace) !important; font-weight: 600; }
+
+/* Brand the active nav tab + links */
+.md-tabs { background: var(--md-primary-fg-color); }
+.md-typeset a:hover { color: var(--md-accent-fg-color); }
+
+/* Friendly, rounded code + admonition blocks to match the landing */
+.md-typeset pre > code { border-radius: 10px; }
+.md-typeset .admonition,
+.md-typeset details { border-radius: 12px; border-left-width: 3px; }
+
+/* Tables: a little more air for the API/spec tables we use heavily */
+.md-typeset table:not([class]) { border-radius: 10px; overflow: hidden; font-size: .78rem; }
+.md-typeset table:not([class]) th { background: var(--md-accent-fg-color--transparent); font-weight: 700; }
+
+/* Buttons rendered from markdown (.md-button) — match brand */
+.md-typeset .md-button {
+  border-radius: 100px; border-width: 1px; font-weight: 600;
+}
+.md-typeset .md-button--primary {
+  background: linear-gradient(180deg, #7c7cf0, #5b5bd6);
+  border-color: transparent; color: #fff;
+}
+.md-typeset .md-button--primary:hover { background: #4a4ac4; border-color: transparent; }
+
+/* mkdocstrings API reference: clearer symbol separation */
+.doc-heading { scroll-margin-top: 4rem; }
+.doc-contents { border-left: 2px solid var(--md-accent-fg-color--transparent); padding-left: 1rem; }
+.doc-symbol { font-size: .7em; }
+
+/* Hide the "made with material" generator note already off via config; keep footer tidy */
+.md-footer-meta { background: #060609; }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,167 @@
+site_name: bharat-courts
+site_url: https://iamshouvikmitra.github.io/bharat-courts/
+site_description: >-
+  Plug India's entire judicial record into the AI you already use. bharat-courts
+  is a free, open-source skill that lets Claude, ChatGPT and your own tools search
+  cases, pull orders and read cause lists from official eCourts sources — locally,
+  with no per-query API fees.
+site_author: Shouvik Mitra
+repo_name: iamshouvikmitra/bharat-courts
+repo_url: https://github.com/iamshouvikmitra/bharat-courts
+edit_uri: edit/main/docs/
+copyright: >-
+  bharat-courts is open-source under the MIT License. Court data is sourced from
+  the official eCourts platform and the Indian Judgments AWS Open Data buckets
+  (CC-BY-4.0, maintained by Dattam Labs).
+
+theme:
+  name: material
+  custom_dir: overrides
+  language: en
+  logo: assets/logo.svg
+  favicon: assets/favicon.svg
+  icon:
+    repo: fontawesome/brands/github
+  font:
+    text: Inter
+    code: JetBrains Mono
+  palette:
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/weather-night
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to dark mode
+  features:
+    - navigation.instant
+    - navigation.instant.progress
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.sections
+    - navigation.top
+    - navigation.footer
+    - navigation.indexes
+    - toc.follow
+    - search.suggest
+    - search.highlight
+    - search.share
+    - content.code.copy
+    - content.code.annotate
+    - content.tabs.link
+    - content.tooltips
+
+extra_css:
+  - stylesheets/extra.css
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/iamshouvikmitra/bharat-courts
+      name: bharat-courts on GitHub
+    - icon: fontawesome/brands/python
+      link: https://pypi.org/project/bharat-courts/
+      name: bharat-courts on PyPI
+  generator: false
+
+plugins:
+  - search
+  - minify:
+      minify_html: true
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          paths: [src]
+          options:
+            docstring_style: google
+            show_source: true
+            show_root_heading: true
+            show_root_full_path: false
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            members_order: source
+            separate_signature: true
+            show_signature_annotations: true
+            signature_crossrefs: true
+            merge_init_into_class: true
+            docstring_section_style: table
+            filters: ["!^_"]
+
+markdown_extensions:
+  - abbr
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+      title: On this page
+  - pymdownx.betterem
+  - pymdownx.caret
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.mark
+  - pymdownx.smartsymbols
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde
+
+nav:
+  - Home: index.md
+  - For Lawyers:
+      - lawyers/index.md
+      - What you can ask: lawyers/prompts.md
+      - Set up in Claude Desktop: lawyers/claude-desktop.md
+      - Set up in Claude Code & CoWork: lawyers/claude-code.md
+      - Use with ChatGPT & other AI: lawyers/chatgpt-and-others.md
+      - Questions & answers: lawyers/faq.md
+  - Getting Started:
+      - start/installation.md
+      - Quickstart: start/quickstart.md
+      - Configuration: start/configuration.md
+  - Guides:
+      - The Judgments facade: guides/facade.md
+      - High Courts: guides/high-courts.md
+      - District Courts: guides/district-courts.md
+      - Calcutta High Court: guides/calcutta-hc.md
+      - Judgment search: guides/judgment-search.md
+      - Supreme Court: guides/supreme-court.md
+      - Historical archive: guides/archive.md
+      - CAPTCHA solving: guides/captcha.md
+      - Command-line interface: guides/cli.md
+  - API Reference:
+      - reference/index.md
+      - Judgments facade: reference/facade.md
+      - Live clients: reference/clients.md
+      - Archive client: reference/archive.md
+      - Data models: reference/models.md
+      - Courts registry: reference/courts.md
+      - CAPTCHA solvers: reference/captcha.md
+      - Configuration: reference/config.md
+  - About:
+      - How it works: about/how-it-works.md
+      - Data & licensing: about/data-sources.md
+      - Contributing: about/contributing.md

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -1,0 +1,287 @@
+{% extends "main.html" %}
+
+<!--
+  Landing page for bharat-courts.
+  Follows Material's documented pattern: inject the marketing page into the
+  `tabs` block (full-bleed, above the content grid) and blank out `content`.
+  Sidebars are hidden via the page's front matter (hide: [navigation, toc]).
+-->
+
+{% block tabs %}
+  {{ super() }}
+
+  <style>{% include "partials/home.css" %}</style>
+
+  <section class="bc-hero">
+    <div class="bc-hero__glow" aria-hidden="true"></div>
+    <div class="bc-wrap bc-hero__inner">
+      <div class="bc-hero__copy">
+        <p class="bc-eyebrow">
+          <span class="bc-dot"></span> Free &amp; open-source · Straight from the official eCourts record
+        </p>
+        <h1 class="bc-hero__title">
+          Every Indian court case.<br>
+          <span class="bc-grad">In the AI you already use.</span>
+        </h1>
+        <p class="bc-hero__sub">
+          <strong>bharat-courts</strong> turns Claude, ChatGPT and your own tools into a tireless
+          research associate — searching cases, pulling orders and reading cause lists across
+          <strong>700+ District Courts</strong>, all <strong>25 High Courts</strong> and the
+          <strong>Supreme Court</strong>. Ask in plain English. Get answers from the official record.
+        </p>
+        <div class="bc-cta">
+          <a class="bc-btn bc-btn--primary" href="lawyers/">Add it to your AI
+            <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M13.3 5.3 14.7 4l8 8-8 8-1.4-1.3 5.6-5.7H1v-2h17.9z"/></svg>
+          </a>
+          <a class="bc-btn bc-btn--ghost" href="start/installation/">Read the docs</a>
+          <a class="bc-btn bc-btn--text" href="https://github.com/iamshouvikmitra/bharat-courts" target="_blank" rel="noopener">
+            <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M12 .5A11.5 11.5 0 0 0 .5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.53-1.34-1.3-1.7-1.3-1.7-1.06-.72.08-.7.08-.7 1.17.08 1.78 1.2 1.78 1.2 1.04 1.78 2.74 1.27 3.4.97.11-.76.41-1.27.74-1.56-2.55-.29-5.23-1.28-5.23-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.8 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.18 1.84 1.18 3.1 0 4.43-2.69 5.41-5.25 5.69.42.37.8 1.1.8 2.22v3.29c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12 11.5 11.5 0 0 0 12 .5"/></svg>
+            GitHub
+          </a>
+        </div>
+        <ul class="bc-stats">
+          <li><span>1950</span>→ today archive</li>
+          <li><span>25</span> High Courts</li>
+          <li><span>700+</span> District Courts</li>
+          <li><span>₹0</span> per query</li>
+        </ul>
+      </div>
+
+      <div class="bc-chat" role="img" aria-label="Example of asking an AI assistant a court-data question">
+        <div class="bc-chat__bar"><span></span><span></span><span></span> bharat-courts · your AI assistant</div>
+        <div class="bc-chat__body">
+          <div class="bc-msg bc-msg--user">
+            Pull every order in WPA 12886 of 2024 before the Calcutta High Court and summarise the latest one.
+          </div>
+          <div class="bc-msg bc-msg--ai">
+            <p>Found the matter (CNR <code>WBCH…2024</code>) and <strong>7 orders</strong> on the official portal.</p>
+            <p>The most recent, dated <strong>11 Mar 2025</strong>, disposes of the interim application and lists the writ for final hearing. I've saved all 7 order PDFs to your folder.</p>
+            <p class="bc-msg__meta">↳ source: calcuttahighcourt.gov.in · fetched locally · 0 API credits used</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="bc-trust">
+      <div class="bc-wrap">
+        <p class="bc-trust__label">Works inside the tools you and your team already trust</p>
+        <ul class="bc-trust__row">
+          <li>Claude Desktop</li>
+          <li>Claude Code</li>
+          <li>Claude CoWork</li>
+          <li>ChatGPT</li>
+          <li>GitHub Copilot</li>
+          <li>Any MCP-compatible assistant</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- PROBLEM -->
+  <section class="bc-section">
+    <div class="bc-wrap">
+      <p class="bc-kicker">The grind you didn't sign up for</p>
+      <h2 class="bc-h2">Litigation runs on data that's painful to reach.</h2>
+      <div class="bc-grid bc-grid--3">
+        <article class="bc-pain">
+          <h3>Portal roulette &amp; CAPTCHAs</h3>
+          <p>You know the case is there. But it's another login, another blurry CAPTCHA, another five clicks — for a single hearing date.</p>
+        </article>
+        <article class="bc-pain">
+          <h3>700+ scattered portals</h3>
+          <p>Every district court has its own dropdown maze. Tracking a matter across forums means re-learning the same form, again and again.</p>
+        </article>
+        <article class="bc-pain">
+          <h3>Subscriptions that still make you click</h3>
+          <p>Premium legal databases cost a fortune each year — and you <em>still</em> end up back on eCourts for the primary record.</p>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <!-- HOW IT WORKS -->
+  <section class="bc-section bc-section--alt">
+    <div class="bc-wrap">
+      <p class="bc-kicker">From install to answer in minutes</p>
+      <h2 class="bc-h2">Three steps. Then just ask.</h2>
+      <div class="bc-steps">
+        <article class="bc-step">
+          <div class="bc-step__n">1</div>
+          <h3>Install it once</h3>
+          <p>Drop the skill into your AI assistant with a single command. No keys, no server, no account.</p>
+          <pre class="bc-code"><code>bharat-courts install-skills</code></pre>
+        </article>
+        <article class="bc-step">
+          <div class="bc-step__n">2</div>
+          <h3>Ask in plain English</h3>
+          <p>Talk to your assistant the way you'd brief a junior — by party, case number, CNR, judge or keyword.</p>
+          <pre class="bc-code"><code>"Is Sharma vs State listed
+ in Bombay HC this week?"</code></pre>
+        </article>
+        <article class="bc-step">
+          <div class="bc-step__n">3</div>
+          <h3>Get the official record</h3>
+          <p>Status, orders, cause lists and 75 years of judgments — with source links and downloadable PDFs.</p>
+          <pre class="bc-code"><code>→ 3 matters · 12 orders
+→ PDFs saved locally</code></pre>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <!-- FEATURES -->
+  <section class="bc-section">
+    <div class="bc-wrap">
+      <p class="bc-kicker">One skill, the whole judicial record</p>
+      <h2 class="bc-h2">Everything an associate would dig up — instantly.</h2>
+      <div class="bc-grid bc-grid--3 bc-features">
+        <article class="bc-card">
+          <div class="bc-ic">{% include "partials/ic_search.svg" %}</div>
+          <h3>Plain-English case lookup</h3>
+          <p>Search by party, case number, CNR or filing year across High Courts and District Courts — no codes to memorise.</p>
+        </article>
+        <article class="bc-card">
+          <div class="bc-ic">{% include "partials/ic_clock.svg" %}</div>
+          <h3>Live status &amp; daily cause lists</h3>
+          <p>Current stage, next hearing date and the day's cause list, pulled fresh from the live portals.</p>
+        </article>
+        <article class="bc-card">
+          <div class="bc-ic">{% include "partials/ic_book.svg" %}</div>
+          <h3>75 years of judgments</h3>
+          <p>The Supreme Court from 1950 and 25 High Courts, searchable by judge, year, citation or keyword.</p>
+        </article>
+        <article class="bc-card">
+          <div class="bc-ic">{% include "partials/ic_pdf.svg" %}</div>
+          <h3>One-tap PDF downloads</h3>
+          <p>Orders, judgments and cause lists fetched and filed to your machine, ready to read or attach.</p>
+        </article>
+        <article class="bc-card">
+          <div class="bc-ic">{% include "partials/ic_lock.svg" %}</div>
+          <h3>Runs on your machine</h3>
+          <p>Queries go straight from your computer to the official source. Your matters stay your business.</p>
+        </article>
+        <article class="bc-card">
+          <div class="bc-ic">{% include "partials/ic_rupee.svg" %}</div>
+          <h3>No per-query fees</h3>
+          <p>Open-source and free. No metered data API, no annual database licence, no surprise bills.</p>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <!-- USE CASES -->
+  <section class="bc-section bc-section--alt">
+    <div class="bc-wrap">
+      <p class="bc-kicker">Built for the way you actually work</p>
+      <h2 class="bc-h2">A research desk that never sleeps.</h2>
+      <div class="bc-grid bc-grid--2 bc-usecases">
+        <article class="bc-use">
+          <h3>The night before a hearing</h3>
+          <p class="bc-use__say">"What's the latest order in this matter, and is it listed tomorrow?"</p>
+          <p>One question, the current stage, the last order and tomorrow's cause-list position — settled before dinner.</p>
+        </article>
+        <article class="bc-use">
+          <h3>Onboarding a new brief</h3>
+          <p class="bc-use__say">"Get the full order history for this CNR and summarise it."</p>
+          <p>Walk into the first conference already across every interim order, in chronological order, with the PDFs in hand.</p>
+        </article>
+        <article class="bc-use">
+          <h3>Hunting for precedent</h3>
+          <p class="bc-use__say">"Find Supreme Court judgments on the right to privacy since 2017."</p>
+          <p>Sweep three-quarters of a century of judgments by judge, year, citation or phrase — without leaving the chat.</p>
+        </article>
+        <article class="bc-use">
+          <h3>The morning cause list</h3>
+          <p class="bc-use__say">"Show me everything listed before my bench today."</p>
+          <p>Start each day with the day's board already pulled, parsed and prioritised.</p>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <!-- LOCAL / COST -->
+  <section class="bc-section bc-band">
+    <div class="bc-wrap bc-band__inner">
+      <div class="bc-band__col">
+        <p class="bc-kicker bc-kicker--light">Confidential by design</p>
+        <h2 class="bc-h2 bc-h2--light">Your practice is privileged.<br>Keep it that way.</h2>
+        <p class="bc-band__p">
+          bharat-courts runs on <strong>your</strong> computer and talks <strong>directly</strong> to the
+          official court sources. There's no bharat-courts server in the middle, no third-party data
+          vendor logging which clients you research, and no cloud account to create.
+        </p>
+        <ul class="bc-checks">
+          <li>Queries go device → official source, full stop</li>
+          <li>Nothing routed through a paid data middleman</li>
+          <li>Open-source — audit every line yourself</li>
+        </ul>
+      </div>
+      <div class="bc-band__col">
+        <p class="bc-kicker bc-kicker--light">The maths is simple</p>
+        <h2 class="bc-h2 bc-h2--light">No metered APIs.<br>No annual licence.</h2>
+        <p class="bc-band__p">
+          Commercial legal-data subscriptions and pay-per-call APIs add up fast. bharat-courts is free
+          and open-source: the only thing you pay for is the AI assistant you're <em>already</em> using.
+        </p>
+        <div class="bc-pricetag">
+          <span class="bc-pricetag__big">₹0</span>
+          <span class="bc-pricetag__sub">per search · per order · per judgment · forever</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- FOR ENGINEERS -->
+  <section class="bc-section">
+    <div class="bc-wrap bc-eng">
+      <div class="bc-eng__copy">
+        <p class="bc-kicker">For the team building legal-tech</p>
+        <h2 class="bc-h2">A real SDK under the skill.</h2>
+        <p class="bc-eng__p">
+          The same engine your assistant uses is a clean, fully-typed async Python library and CLI.
+          Federated search that auto-routes between the live portals and a DuckDB-backed historical
+          archive, pluggable CAPTCHA solving, and dataclasses that serialise straight to JSON.
+        </p>
+        <div class="bc-cta">
+          <a class="bc-btn bc-btn--primary" href="guides/facade/">Explore the guides</a>
+          <a class="bc-btn bc-btn--ghost" href="reference/">API reference</a>
+        </div>
+        <ul class="bc-eng__tags">
+          <li>async / await</li><li>typed dataclasses</li><li>pip install</li>
+          <li>CLI + JSON</li><li>pytest · 250 tests</li><li>MIT licensed</li>
+        </ul>
+      </div>
+      <div class="bc-eng__code">
+        <pre class="bc-code bc-code--block"><code>import asyncio
+from bharat_courts import Judgments
+
+async def main():
+    async with Judgments() as j:
+        hits = await j.find(
+            judge="chandrachud",
+            year=(2018, 2024),
+            court="sci",
+            limit=10,
+        )
+        for r in hits:
+            print(r.decision_date, r.title)
+
+asyncio.run(main())</code></pre>
+      </div>
+    </div>
+  </section>
+
+  <!-- FINAL CTA -->
+  <section class="bc-final">
+    <div class="bc-wrap bc-final__inner">
+      <h2>Give your AI the court record.</h2>
+      <p>Five minutes to set up. Free forever. Sourced straight from the official portals.</p>
+      <div class="bc-cta bc-cta--center">
+        <a class="bc-btn bc-btn--primary bc-btn--lg" href="lawyers/">Get started — it's free</a>
+        <a class="bc-btn bc-btn--ghost bc-btn--lg" href="lawyers/prompts/">See what you can ask</a>
+      </div>
+    </div>
+  </section>
+{% endblock %}
+
+{% block content %}{% endblock %}

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,82 @@
+{% extends "base.html" %}
+
+<!--
+  SEO + social metadata for every page. This site is fully static / pre-rendered
+  (one complete HTML document per route), so all content is crawlable on first
+  byte — no client-side hydration required. These tags add descriptions, Open
+  Graph / Twitter cards, canonical URLs and structured data on top of that.
+-->
+
+{% block extrahead %}
+  {# Display serif (Fraunces) for headlines — Inter (body) and JetBrains Mono
+     (code) are loaded by the Material theme. #}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&display=swap">
+
+  {# Resolve a per-page title + description, falling back to site defaults. #}
+  {%- if page and page.meta and page.meta.title -%}
+    {%- set seo_title = page.meta.title -%}
+  {%- elif page and page.title and not page.is_homepage -%}
+    {%- set seo_title = page.title ~ " · " ~ config.site_name -%}
+  {%- else -%}
+    {%- set seo_title = config.site_name ~ " — Indian court data, in the AI you already use" -%}
+  {%- endif -%}
+
+  {%- if page and page.meta and page.meta.description -%}
+    {%- set seo_desc = page.meta.description -%}
+  {%- else -%}
+    {%- set seo_desc = config.site_description -%}
+  {%- endif -%}
+
+  {%- set seo_image = config.site_url ~ "assets/og-image.png" -%}
+  {%- set seo_url = page.canonical_url if page else config.site_url -%}
+
+  {# Material already emits <meta name="description"> when a page sets one, and a
+     <link rel="canonical"> from site_url. Only add a description fallback for
+     pages that don't define their own, to avoid duplicate tags. #}
+  {%- if not (page and page.meta and page.meta.description) %}
+  <meta name="description" content="{{ seo_desc | striptags | trim }}">
+  {%- endif %}
+  <meta name="robots" content="index, follow, max-image-preview:large">
+  <meta name="author" content="{{ config.site_author }}">
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="{{ config.site_name }}">
+  <meta property="og:title" content="{{ seo_title }}">
+  <meta property="og:description" content="{{ seo_desc | striptags | trim }}">
+  <meta property="og:url" content="{{ seo_url }}">
+  <meta property="og:image" content="{{ seo_image }}">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:locale" content="en_IN">
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{ seo_title }}">
+  <meta name="twitter:description" content="{{ seo_desc | striptags | trim }}">
+  <meta name="twitter:image" content="{{ seo_image }}">
+
+  {# Structured data: describe the software on the home page for rich results. #}
+  {%- if page and page.is_homepage %}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "bharat-courts",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Cross-platform (Python 3.11+)",
+    "description": {{ config.site_description | striptags | trim | tojson }},
+    "url": {{ config.site_url | tojson }},
+    "downloadUrl": "https://pypi.org/project/bharat-courts/",
+    "softwareHelp": {{ (config.site_url ~ "start/installation/") | tojson }},
+    "license": "https://opensource.org/licenses/MIT",
+    "isAccessibleForFree": true,
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "INR" },
+    "author": { "@type": "Person", "name": {{ config.site_author | tojson }} },
+    "codeRepository": {{ config.repo_url | tojson }}
+  }
+  </script>
+  {% endif -%}
+{% endblock %}

--- a/overrides/partials/home.css
+++ b/overrides/partials/home.css
@@ -1,0 +1,312 @@
+/* ============================================================
+   bharat-courts — landing page (modern legal-tech SaaS)
+   ink #0B0B12 · indigo #5B5BD6 · Inter
+   Scoped styles, inlined only on the home template.
+   ============================================================ */
+
+:root {
+  --bc-ink: #0b0b12;
+  --bc-ink-2: #12121c;
+  --bc-indigo: #5b5bd6;
+  --bc-indigo-2: #7c7cf0;
+  --bc-indigo-soft: rgba(91, 91, 214, 0.12);
+  --bc-text: #1b1b27;
+  --bc-muted: #5a5a6e;
+  --bc-line: rgba(20, 20, 35, 0.10);
+  --bc-card: #ffffff;
+  --bc-surface: #f6f6fb;
+  --bc-radius: 16px;
+  /* Viewport-relative so big monitors fill instead of leaving wide gutters,
+     while laptops stay tidy. ~92vw on a 1440 screen ≈ 1325px. */
+  --bc-maxw: min(1640px, 92vw);
+  /* Type roles: serif display, sans body (Inter via theme), mono accents. */
+  --bc-display: "Fraunces", "Iowan Old Style", Georgia, serif;
+  --bc-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, monospace;
+}
+
+[data-md-color-scheme="slate"] {
+  --bc-text: #e7e7f0;
+  --bc-muted: #a6a6bd;
+  --bc-line: rgba(255, 255, 255, 0.10);
+  --bc-card: #15151f;
+  --bc-surface: #0f0f17;
+}
+
+/* The landing owns full width; kill the empty content grid + sidebars. */
+.md-main__inner { margin-top: 0; }
+.md-content { max-width: none; }
+.md-content__inner { margin: 0; padding: 0; }
+.md-content__inner::before { display: none; }
+.md-sidebar { display: none; }
+
+.bc-wrap {
+  max-width: var(--bc-maxw);
+  margin: 0 auto;
+  padding: 0 2.5rem;
+}
+/* Material caps the tabs/header grid at 61rem; let the landing breathe wider. */
+.md-main__inner.md-grid,
+.bc-hero .md-grid { max-width: none; }
+
+/* ---------- HERO ---------- */
+.bc-hero {
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(1200px 600px at 85% -10%, rgba(124, 124, 240, 0.28), transparent 60%),
+    radial-gradient(900px 500px at 5% 10%, rgba(91, 91, 214, 0.18), transparent 55%),
+    var(--bc-ink);
+  color: #fff;
+  padding: 3rem 0 0;
+}
+.bc-hero__glow {
+  position: absolute; inset: 0;
+  background-image:
+    linear-gradient(rgba(255,255,255,0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,0.04) 1px, transparent 1px);
+  background-size: 46px 46px;
+  mask-image: radial-gradient(700px 380px at 70% 0%, #000 30%, transparent 75%);
+  pointer-events: none;
+}
+.bc-hero__inner {
+  position: relative;
+  display: grid;
+  grid-template-columns: 1.05fr 0.9fr;
+  gap: 3.5rem;
+  align-items: center;
+}
+.bc-eyebrow {
+  display: inline-flex; align-items: center; gap: .55rem;
+  font-family: var(--bc-mono); font-size: .7rem; font-weight: 500; letter-spacing: .02em;
+  color: #c9c9e6;
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.12);
+  padding: .35rem .75rem; border-radius: 100px;
+}
+.bc-dot { width: 7px; height: 7px; border-radius: 50%; background: #4ade80; box-shadow: 0 0 0 4px rgba(74,222,128,.18); }
+.bc-hero__title {
+  font-family: var(--bc-display);
+  /* Slower growth + lower cap so the headline never dominates on any display. */
+  font-size: clamp(1.95rem, 2.9vw, 2.7rem);
+  line-height: 1.08; font-weight: 600; letter-spacing: -0.015em;
+  margin: 1.1rem 0 .9rem; color: #fff;
+  text-wrap: balance;
+}
+.bc-grad {
+  background: linear-gradient(92deg, var(--bc-indigo-2), #b7b7ff 60%, #fff);
+  -webkit-background-clip: text; background-clip: text; color: transparent;
+}
+.bc-hero__sub {
+  font-size: .98rem; line-height: 1.6; color: #c6c6da; max-width: 33rem; margin: 0 0 1.6rem;
+}
+.bc-hero__sub strong { color: #fff; font-weight: 600; }
+
+.bc-cta { display: flex; flex-wrap: wrap; gap: .75rem; align-items: center; }
+.bc-cta--center { justify-content: center; }
+.bc-btn {
+  display: inline-flex; align-items: center; gap: .5rem;
+  font-weight: 600; font-size: .95rem; border-radius: 100px;
+  padding: .75rem 1.4rem; transition: transform .15s ease, box-shadow .2s ease, background .2s ease;
+  text-decoration: none; cursor: pointer; white-space: nowrap;
+}
+.bc-btn--lg { padding: .9rem 1.8rem; font-size: 1.02rem; }
+.bc-btn--primary {
+  background: linear-gradient(180deg, var(--bc-indigo-2), var(--bc-indigo));
+  color: #fff; box-shadow: 0 10px 30px -8px rgba(91,91,214,.6);
+}
+.bc-btn--primary:hover { transform: translateY(-2px); box-shadow: 0 16px 38px -8px rgba(91,91,214,.7); }
+.bc-btn--ghost {
+  background: rgba(255,255,255,0.04); color: #fff; border: 1px solid rgba(255,255,255,0.18);
+}
+.bc-btn--ghost:hover { background: rgba(255,255,255,0.10); transform: translateY(-2px); }
+.bc-btn--text { color: #c9c9e6; background: transparent; padding-left: .6rem; padding-right: .6rem; }
+.bc-btn--text:hover { color: #fff; }
+
+/* on light sections the ghost button must flip */
+.bc-section .bc-btn--ghost { color: var(--bc-text); border-color: var(--bc-line); background: transparent; }
+.bc-section .bc-btn--ghost:hover { background: var(--bc-indigo-soft); }
+
+.bc-stats {
+  list-style: none; margin: 2rem 0 0; padding: 0;
+  display: flex; flex-wrap: wrap; gap: 1.8rem;
+  border-top: 1px solid rgba(255,255,255,0.10); padding-top: 1.4rem;
+}
+.bc-stats li { font-family: var(--bc-mono); font-size: .72rem; color: #9b9bb5; }
+.bc-stats span { display: block; font-family: var(--bc-display); font-size: 1.45rem; font-weight: 600; color: #fff; letter-spacing: -.01em; margin-bottom: .15rem; }
+
+/* chat mock */
+.bc-chat {
+  background: linear-gradient(180deg, #1a1a28, #14141f);
+  border: 1px solid rgba(255,255,255,0.10);
+  border-radius: 18px; overflow: hidden;
+  box-shadow: 0 40px 80px -30px rgba(0,0,0,.7), 0 0 0 1px rgba(124,124,240,.10);
+}
+.bc-chat__bar {
+  display: flex; align-items: center; gap: .4rem;
+  padding: .75rem 1rem; font-family: var(--bc-mono); font-size: .72rem; color: #8c8ca6;
+  border-bottom: 1px solid rgba(255,255,255,0.08); background: rgba(255,255,255,0.02);
+}
+.bc-chat__bar span { width: 11px; height: 11px; border-radius: 50%; background: #3a3a4d; }
+.bc-chat__bar span:nth-child(1) { background: #ff5f57; }
+.bc-chat__bar span:nth-child(2) { background: #febc2e; }
+.bc-chat__bar span:nth-child(3) { background: #28c840; margin-right: .5rem; }
+.bc-chat__body { padding: 1.2rem; display: flex; flex-direction: column; gap: .9rem; }
+.bc-msg { padding: .85rem 1.05rem; border-radius: 14px; font-size: .86rem; line-height: 1.5; }
+.bc-msg--user {
+  align-self: flex-end; max-width: 88%;
+  background: linear-gradient(180deg, var(--bc-indigo), #4a4ac4); color: #fff;
+  border-bottom-right-radius: 5px;
+}
+.bc-msg--ai {
+  align-self: flex-start; max-width: 94%;
+  background: rgba(255,255,255,0.05); color: #d8d8e8; border: 1px solid rgba(255,255,255,0.08);
+  border-bottom-left-radius: 5px;
+}
+.bc-msg--ai p { margin: 0 0 .55rem; }
+.bc-msg--ai p:last-child { margin-bottom: 0; }
+.bc-msg--ai strong { color: #fff; }
+.bc-msg code { background: rgba(124,124,240,.18); color: #c9c9ff; padding: .05rem .35rem; border-radius: 5px; font-size: .85em; }
+.bc-msg__meta { font-size: .76rem !important; color: #7e7e98 !important; border-top: 1px dashed rgba(255,255,255,.10); padding-top: .55rem; }
+
+/* trust strip */
+.bc-trust { margin-top: 3rem; border-top: 1px solid rgba(255,255,255,0.08); background: rgba(0,0,0,0.18); padding: 1.6rem 0; }
+.bc-trust__label { font-family: var(--bc-mono); text-align: center; font-size: .74rem; color: #8888a3; margin: 0 0 1rem; letter-spacing: .04em; }
+.bc-trust__row {
+  list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; justify-content: center;
+  gap: .6rem 2.1rem; align-items: center;
+}
+.bc-trust__row li { color: #c4c4dc; font-weight: 600; font-size: .9rem; opacity: .85; }
+
+/* ---------- SECTIONS ---------- */
+.bc-section { padding: 3.25rem 0; background: var(--bc-card); color: var(--bc-text); }
+.bc-section--alt { background: var(--bc-surface); }
+.bc-kicker { font-family: var(--bc-mono); color: var(--bc-indigo); font-weight: 600; font-size: .72rem; letter-spacing: .06em; text-transform: uppercase; margin: 0 0 .6rem; }
+.bc-kicker--light { color: var(--bc-indigo-2); }
+.bc-h2 { font-family: var(--bc-display); font-size: clamp(1.5rem, 2.6vw, 2.1rem); font-weight: 600; letter-spacing: -.015em; line-height: 1.15; margin: 0 0 1.7rem; }
+.bc-h2--light { color: #fff; }
+
+.bc-grid { display: grid; gap: 1.1rem; }
+.bc-grid--2 { grid-template-columns: repeat(2, 1fr); }
+.bc-grid--3 { grid-template-columns: repeat(3, 1fr); }
+
+/* pain cards */
+.bc-pain { padding: 1.4rem; border-radius: var(--bc-radius); border: 1px solid var(--bc-line); background: var(--bc-surface); }
+.bc-section--alt .bc-pain { background: var(--bc-card); }
+.bc-pain h3 { font-size: 1.05rem; font-weight: 700; margin: 0 0 .5rem; }
+.bc-pain p { color: var(--bc-muted); margin: 0; line-height: 1.6; }
+
+/* steps */
+.bc-steps { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.1rem; counter-reset: step; }
+.bc-step { position: relative; padding: 1.6rem 1.5rem 1.4rem; border-radius: var(--bc-radius); background: var(--bc-card); border: 1px solid var(--bc-line); }
+.bc-step__n {
+  width: 40px; height: 40px; border-radius: 11px; display: grid; place-items: center;
+  font-weight: 800; color: #fff; margin-bottom: 1rem;
+  background: linear-gradient(180deg, var(--bc-indigo-2), var(--bc-indigo));
+  box-shadow: 0 8px 20px -8px rgba(91,91,214,.7);
+}
+.bc-step h3 { font-size: 1.05rem; font-weight: 700; margin: 0 0 .45rem; }
+.bc-step p { color: var(--bc-muted); margin: 0 0 1rem; line-height: 1.55; }
+
+.bc-code {
+  background: var(--bc-ink); color: #c9c9ff; border-radius: 11px; padding: .85rem 1rem;
+  font-family: "JetBrains Mono", ui-monospace, monospace; font-size: .82rem; line-height: 1.5;
+  overflow-x: auto; border: 1px solid rgba(124,124,240,.18); margin: 0;
+}
+.bc-code code { background: none; color: inherit; padding: 0; font-size: inherit; white-space: pre; }
+
+/* feature cards */
+.bc-card {
+  padding: 1.5rem; border-radius: var(--bc-radius); background: var(--bc-surface);
+  border: 1px solid var(--bc-line); transition: transform .18s ease, box-shadow .25s ease, border-color .25s ease;
+}
+.bc-section--alt .bc-card { background: var(--bc-card); }
+.bc-card:hover { transform: translateY(-4px); box-shadow: 0 24px 50px -28px rgba(20,20,40,.45); border-color: rgba(91,91,214,.35); }
+.bc-ic {
+  width: 52px; height: 52px; border-radius: 13px; display: grid; place-items: center; color: var(--bc-indigo);
+  background: var(--bc-indigo-soft); margin-bottom: 1rem;
+}
+.bc-card h3 { font-size: 1.05rem; font-weight: 700; margin: 0 0 .45rem; }
+.bc-card p { color: var(--bc-muted); margin: 0; line-height: 1.6; }
+
+/* use cases */
+.bc-use { padding: 1.5rem; border-radius: var(--bc-radius); background: var(--bc-card); border: 1px solid var(--bc-line); }
+.bc-use h3 { font-family: var(--bc-display); font-size: 1.2rem; font-weight: 600; margin: 0 0 .7rem; letter-spacing: -.01em; }
+.bc-use__say {
+  font-size: .98rem; font-weight: 600; color: var(--bc-text); line-height: 1.5;
+  border-left: 3px solid var(--bc-indigo); padding: .2rem 0 .2rem 1rem; margin: 0 0 .9rem; font-style: italic;
+}
+.bc-use > p:last-child { color: var(--bc-muted); margin: 0; line-height: 1.6; }
+
+/* dark band */
+.bc-band {
+  background:
+    radial-gradient(900px 500px at 90% 0%, rgba(124,124,240,.22), transparent 60%),
+    var(--bc-ink);
+  color: #fff;
+}
+.bc-band__inner { display: grid; grid-template-columns: 1fr 1fr; gap: 3rem; }
+.bc-band__p { color: #c2c2d6; line-height: 1.65; font-size: .95rem; }
+.bc-band__p strong { color: #fff; }
+.bc-checks { list-style: none; padding: 0; margin: 1.3rem 0 0; display: grid; gap: .7rem; }
+.bc-checks li { position: relative; padding-left: 1.9rem; color: #d2d2e4; line-height: 1.5; }
+.bc-checks li::before {
+  content: ""; position: absolute; left: 0; top: 2px; width: 20px; height: 20px; border-radius: 50%;
+  background: rgba(74,222,128,.16) url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="%234ade80" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>') center/12px no-repeat;
+}
+.bc-pricetag { margin-top: 1.6rem; display: flex; align-items: baseline; gap: .9rem; flex-wrap: wrap; }
+.bc-pricetag__big {
+  font-family: var(--bc-display); font-size: 2.8rem; font-weight: 600; letter-spacing: -.03em; line-height: 1;
+  background: linear-gradient(180deg, #fff, var(--bc-indigo-2)); -webkit-background-clip: text; background-clip: text; color: transparent;
+}
+.bc-pricetag__sub { color: #a6a6c0; font-size: .95rem; }
+
+/* engineers */
+.bc-eng { display: grid; grid-template-columns: 1.05fr 0.95fr; gap: 3rem; align-items: center; }
+.bc-eng__p { color: var(--bc-muted); line-height: 1.65; font-size: .96rem; margin: 0 0 1.5rem; }
+.bc-eng__tags { list-style: none; padding: 0; margin: 1.6rem 0 0; display: flex; flex-wrap: wrap; gap: .6rem; }
+.bc-eng__tags li { font-size: .82rem; font-weight: 600; color: var(--bc-muted); border: 1px solid var(--bc-line); border-radius: 100px; padding: .35rem .85rem; }
+.bc-code--block { font-size: .88rem; padding: 1.5rem; line-height: 1.65; box-shadow: 0 30px 60px -30px rgba(20,20,40,.5); }
+
+/* final cta */
+.bc-final {
+  text-align: center; padding: 4rem 0;
+  background:
+    radial-gradient(700px 380px at 50% 120%, rgba(124,124,240,.30), transparent 60%),
+    linear-gradient(180deg, var(--bc-ink-2), var(--bc-ink));
+  color: #fff;
+}
+.bc-final h2 { font-family: var(--bc-display); font-size: clamp(1.7rem, 3vw, 2.4rem); font-weight: 600; letter-spacing: -.02em; margin: 0 0 .8rem; }
+.bc-final p { color: #c2c2d6; font-size: 1rem; margin: 0 0 2rem; }
+
+/* ---------- large monitors: fill the screen via container width, NOT giant type ---------- */
+@media (min-width: 1600px) {
+  /* Keep the hero restrained — let the wider container do the filling. */
+  .bc-hero { padding-top: 3rem; }
+  .bc-hero__inner { grid-template-columns: 1.15fr 0.85fr; gap: 4rem; }
+  .bc-hero__title { font-size: 2.5rem; }
+  .bc-hero__sub { font-size: 1.02rem; max-width: 36rem; }
+  .bc-section { padding: 4.25rem 0; }
+  .bc-h2 { font-size: clamp(1.9rem, 2vw, 2.2rem); }
+  .bc-grid, .bc-steps { gap: 1.5rem; }
+  .bc-card, .bc-use { padding: 1.8rem; }
+  .bc-stats span { font-size: 1.4rem; }
+}
+@media (min-width: 2100px) {
+  .bc-hero__title { font-size: 2.8rem; }
+  .bc-hero__sub { font-size: 1.08rem; }
+  .bc-h2 { font-size: 2.4rem; }
+  .bc-section { padding: 5rem 0; }
+}
+
+/* ---------- responsive ---------- */
+@media (max-width: 960px) {
+  .bc-hero__inner { grid-template-columns: 1fr; gap: 2.5rem; padding-top: 1rem; }
+  .bc-band__inner, .bc-eng { grid-template-columns: 1fr; gap: 2.5rem; }
+  .bc-grid--3, .bc-steps { grid-template-columns: 1fr 1fr; }
+}
+@media (max-width: 720px) {
+  .bc-hero { padding-top: 3.5rem; }
+  .bc-grid--2, .bc-grid--3, .bc-steps { grid-template-columns: 1fr; }
+  .bc-section, .bc-band { padding: 3.5rem 0; }
+  .bc-stats { gap: 1.2rem 1.8rem; }
+}

--- a/overrides/partials/ic_book.svg
+++ b/overrides/partials/ic_book.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4.5A2.5 2.5 0 0 1 6.5 2H20v18H6.5A2.5 2.5 0 0 0 4 22.5z"/><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/></svg>

--- a/overrides/partials/ic_clock.svg
+++ b/overrides/partials/ic_clock.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3.5 2"/></svg>

--- a/overrides/partials/ic_lock.svg
+++ b/overrides/partials/ic_lock.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="10" width="16" height="11" rx="2"/><path d="M8 10V7a4 4 0 0 1 8 0v3"/><path d="M12 15v2"/></svg>

--- a/overrides/partials/ic_pdf.svg
+++ b/overrides/partials/ic_pdf.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6.5A1.5 1.5 0 0 0 5 3.5v17A1.5 1.5 0 0 0 6.5 22h11a1.5 1.5 0 0 0 1.5-1.5V7z"/><path d="M14 2v5h5"/><path d="M9 13h1.5a1.5 1.5 0 0 1 0 3H9zm0 0v5"/></svg>

--- a/overrides/partials/ic_rupee.svg
+++ b/overrides/partials/ic_rupee.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M9 8h6M9 11h6M9 8c3 0 4 1 4 3s-1 3-4 3l4 4"/></svg>

--- a/overrides/partials/ic_search.svg
+++ b/overrides/partials/ic_search.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,8 @@
+# Documentation toolchain (MkDocs Material + auto API reference).
+# mkdocstrings uses griffe's static analysis, so the package's runtime
+# dependencies do NOT need to be installed to build the API reference.
+mkdocs-material>=9.5
+mkdocstrings[python]>=0.27
+mkdocs-minify-plugin>=0.8
+# Used by mkdocstrings to pretty-format API signatures in the reference.
+black>=24.0


### PR DESCRIPTION
Adds the marketing landing page + full documentation site, auto-API reference (mkdocstrings), SEO metadata, and a GitHub Actions workflow that deploys to GitHub Pages on merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)