### PR TITLE
fix(hcservices): cause list PDF links joined against wrong path, always 404

### DIFF
--- a/src/bharat_courts/hcservices/parser.py
+++ b/src/bharat_courts/hcservices/parser.py
@@ -379,7 +379,9 @@ def parse_cause_list(html: str, base_url: str = "") -> list[CauseListPDF]:
             if href.startswith("http"):
                 pdf_url = href
             elif base_url:
-                pdf_url = f"{base_url}/cases_qry/{href}"
+                # hrefs like "cases/display_causelist_pdf.php?..." are relative
+                # to the /hcservices root (the main page), not cases_qry/
+                pdf_url = f"{base_url}/{href.lstrip('/')}"
             else:
                 pdf_url = href
 

--- a/tests/test_hcservices_parser.py
+++ b/tests/test_hcservices_parser.py
@@ -169,7 +169,10 @@ def test_parse_cause_list(hcservices_cause_list_html):
     assert entry1.serial_number == 1
     assert "DIVISION BENCH" in entry1.bench
     assert entry1.cause_list_type == "COMPLETE CAUSE LIST"
-    assert "display_causelist_pdf.php" in entry1.pdf_url
+    assert entry1.pdf_url.startswith(
+        "https://hcservices.ecourts.gov.in/hcservices/cases/display_causelist_pdf.php?"
+    )
+    assert "/cases_qry/" not in entry1.pdf_url
 
     entry2 = results[1]
     assert entry2.serial_number == 2


### PR DESCRIPTION
## Problem

`parse_cause_list()` joins relative causelist hrefs as `{base_url}/cases_qry/{href}`. The portal returns hrefs like:

```
cases/display_causelist_pdf.php?filename=...&causelistYear=2026
```

which are relative to the `/hcservices/` root (the main page), **not** the `cases_qry/` AJAX path. The resulting URL

```
https://hcservices.ecourts.gov.in/hcservices/cases_qry/cases/display_causelist_pdf.php?...
```

404s with the portal's "Welcome User Search Page not Found" page — so every `pdf_url` returned by the cause list API is broken.

## Fix

Join against the `/hcservices` root instead:

```python
pdf_url = f"{base_url}/{href.lstrip('/')}"
```

## Verification

Verified live on 2026-07-12 against Bombay High Court: the corrected URL
`https://hcservices.ecourts.gov.in/hcservices/cases/display_causelist_pdf.php?...` returns `200 application/pdf`, while the old `cases_qry/`-prefixed URL returns the "Page not Found" HTML.

Tightened `test_parse_cause_list` to assert the full resolved URL prefix and reject any `/cases_qry/` in the output; `tests/test_hcservices_parser.py` passes 11/11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)