### PR TITLE
feat(hcservices): add advocate search and advocate cause list

### DIFF
--- a/src/bharat_courts/hcservices/client.py
+++ b/src/bharat_courts/hcservices/client.py
@@ -23,12 +23,13 @@ from bharat_courts.config import config as default_config
 from bharat_courts.hcservices import endpoints
 from bharat_courts.hcservices.parser import (
     CaptchaError,
+    parse_advocate_cause_list,
     parse_case_status,
     parse_cause_list,
     parse_orders,
 )
 from bharat_courts.http import RateLimitedClient
-from bharat_courts.models import CaseInfo, CaseOrder, CauseListPDF, Court
+from bharat_courts.models import CaseInfo, CaseOrder, CauseListEntry, CauseListPDF, Court
 
 logger = logging.getLogger(__name__)
 
@@ -203,6 +204,100 @@ class HCServicesClient:
         for r in results:
             r.court_name = court.name
         return results
+
+    async def case_status_by_advocate(
+        self,
+        court: Court,
+        *,
+        advocate_name: str | None = None,
+        bar_code: str | None = None,
+        bench_code: str = "1",
+        status_filter: str = "Both",
+    ) -> list[CaseInfo]:
+        """Search an advocate's cases by name or bar registration number.
+
+        Unlike :meth:`case_status_by_party` this needs no year, so a single
+        call returns the advocate's whole book — useful for onboarding a
+        practice without entering case numbers by hand.
+
+        Name search is a substring match, so it can pull in other advocates.
+        Each result carries the acting advocates in
+        ``adv_name1``/``adv_name2`` with a bracketed court id
+        ("MR. HEMAL SHAH(6960)"); filter on that id when an exact match
+        matters. Bar-code search does not need filtering.
+
+        Args:
+            court: Court object.
+            advocate_name: Advocate name, full or partial (min 3 chars).
+            bar_code: Bar registration number as ``<STATE>/<NUMBER>/<YEAR>``,
+                e.g. "G/504/2011".
+            bench_code: Bench code from :meth:`list_benches` (default "1").
+            status_filter: "Pending", "Disposed", or "Both".
+
+        Returns:
+            List of matching CaseInfo objects. Results are one row per
+            party, so a case with several petitioners repeats.
+
+        Raises:
+            ValueError: If neither or both of advocate_name / bar_code given.
+        """
+
+        def build_form(captcha: str) -> dict:
+            return endpoints.case_status_by_advocate_form(
+                state_code=court.state_code,
+                court_code=bench_code,
+                captcha=captcha,
+                advocate_name=advocate_name,
+                bar_code=bar_code,
+                status_filter=status_filter,
+            )
+
+        resp = await self._post_with_captcha_retry(endpoints.SHOW_RECORDS_URL, build_form)
+        results = parse_case_status(resp.text)
+        for r in results:
+            r.court_name = court.name
+        return results
+
+    async def advocate_cause_list(
+        self,
+        court: Court,
+        *,
+        bar_code: str,
+        causelist_date: str,
+        bench_code: str = "1",
+    ) -> list[CauseListEntry]:
+        """Fetch an advocate's cause list for a given date.
+
+        This is the court's own answer to "what do I have on this date",
+        so it needs no matching against a party or advocate name.
+
+        Rows are per-party; pass the result through
+        :func:`~bharat_courts.hcservices.parser.dedupe_by_cnr` for one entry
+        per case. No item/serial number is returned — that appears only in
+        the cause list PDF.
+
+        Args:
+            court: Court object.
+            bar_code: Bar registration number, e.g. "G/504/2011".
+            causelist_date: Listing date as ``DD-MM-YYYY``. The portal
+                rejects dates more than one month ahead.
+            bench_code: Bench code from :meth:`list_benches` (default "1").
+
+        Returns:
+            List of CauseListEntry, one per party per listed case.
+        """
+
+        def build_form(captcha: str) -> dict:
+            return endpoints.advocate_cause_list_form(
+                state_code=court.state_code,
+                court_code=bench_code,
+                captcha=captcha,
+                bar_code=bar_code,
+                causelist_date=causelist_date,
+            )
+
+        resp = await self._post_with_captcha_retry(endpoints.SHOW_RECORDS_URL, build_form)
+        return parse_advocate_cause_list(resp.text)
 
     async def court_orders(
         self,

--- a/src/bharat_courts/hcservices/endpoints.py
+++ b/src/bharat_courts/hcservices/endpoints.py
@@ -122,6 +122,98 @@ def case_status_by_party_form(
     }
 
 
+def case_status_by_advocate_form(
+    *,
+    state_code: str,
+    court_code: str = "1",
+    captcha: str,
+    advocate_name: str | None = None,
+    bar_code: str | None = None,
+    status_filter: str = "Both",
+) -> dict[str, str]:
+    """Build form data for case status search by advocate name or bar code.
+
+    Derived from the portal's advocate branch of ``funShowRecords()``. The
+    radio group ``radAdvt`` selects the mode and the JS maps it to a
+    ``search_type`` value: 1 = advocate name, 2 = bar registration number.
+
+    Note: ``caseStatusSearchType`` is ``CSAdvName`` for **both** modes. The
+    portal also defines a ``CSAdvNamebar`` label, but sending it as the
+    search type makes the server return ERROR_VAL — ``search_type`` is what
+    selects name vs bar code.
+
+    Args:
+        state_code: HC state code from courts registry.
+        court_code: Bench code from fillHCBench (default "1" = principal).
+        captcha: Solved CAPTCHA text.
+        advocate_name: Advocate name, full or partial (min 3 chars).
+        bar_code: Bar registration number as ``<STATE>/<NUMBER>/<YEAR>``,
+            e.g. "G/504/2011". Note this is *not* the bracketed id shown
+            beside advocate names in results ("MR. HEMAL SHAH(6960)"); that
+            is an internal court id.
+        status_filter: "Pending", "Disposed", or "Both".
+
+    Raises:
+        ValueError: If neither or both of advocate_name / bar_code are given.
+    """
+    if bool(advocate_name) == bool(bar_code):
+        raise ValueError("pass exactly one of advocate_name or bar_code")
+
+    form = {
+        "court_code": court_code,
+        "state_code": state_code,
+        "court_complex_code": court_code,
+        "caseStatusSearchType": "CSAdvName",
+        "captcha": captcha,
+        "f": status_filter,
+    }
+    if advocate_name:
+        form["advocate_name"] = advocate_name
+        form["search_type"] = "1"
+    else:
+        form["adv_bar_state"] = bar_code or ""
+        form["search_type"] = "2"
+    return form
+
+
+def advocate_cause_list_form(
+    *,
+    state_code: str,
+    court_code: str = "1",
+    captcha: str,
+    bar_code: str,
+    causelist_date: str,
+) -> dict[str, str]:
+    """Build form data for an advocate's cause list on a given date.
+
+    This is ``search_type=3`` of the same advocate branch. Unlike the two
+    search modes it takes a fixed ``f=date_case_list`` rather than a
+    pending/disposed filter, and it requires a bar code — advocate name is
+    not accepted for this mode.
+
+    Note: the portal rejects dates more than one month ahead
+    (``checkDateInpuWithNextMonth``).
+
+    Args:
+        state_code: HC state code from courts registry.
+        court_code: Bench code from fillHCBench (default "1" = principal).
+        captcha: Solved CAPTCHA text.
+        bar_code: Bar registration number, e.g. "G/504/2011".
+        causelist_date: Listing date as ``DD-MM-YYYY``.
+    """
+    return {
+        "court_code": court_code,
+        "state_code": state_code,
+        "court_complex_code": court_code,
+        "caseStatusSearchType": "CSAdvName",
+        "captcha": captcha,
+        "adv_bar_state": bar_code,
+        "caselist_date_dmy": causelist_date,
+        "search_type": "3",
+        "f": "date_case_list",
+    }
+
+
 def court_orders_form(
     *,
     state_code: str,

--- a/src/bharat_courts/hcservices/parser.py
+++ b/src/bharat_courts/hcservices/parser.py
@@ -20,7 +20,7 @@ from datetime import date, datetime
 
 from bs4 import BeautifulSoup, Tag
 
-from bharat_courts.models import CaseInfo, CaseOrder, CauseListPDF
+from bharat_courts.models import CaseInfo, CaseOrder, CauseListEntry, CauseListPDF
 
 logger = logging.getLogger(__name__)
 
@@ -33,15 +33,21 @@ DATE_FORMAT = "%d-%m-%Y"
 
 
 def _parse_date(text: str) -> date | None:
-    """Parse DD-MM-YYYY date string."""
+    """Parse a portal date string.
+
+    Most endpoints use DD-MM-YYYY, but the advocate cause list returns
+    ``date_next_list`` as ISO (YYYY-MM-DD), so ISO is tried as a fallback.
+    """
     text = text.strip()
-    if not text:
+    if not text or text.lower() in {"none", "null", "-", "--"}:
         return None
-    try:
-        return datetime.strptime(text, DATE_FORMAT).date()
-    except ValueError:
-        logger.debug("Could not parse date: %s", text)
-        return None
+    for fmt in (DATE_FORMAT, "%Y-%m-%d"):
+        try:
+            return datetime.strptime(text, fmt).date()
+        except ValueError:
+            continue
+    logger.debug("Could not parse date: %s", text)
+    return None
 
 
 def _clean_text(text: str | None) -> str:
@@ -156,6 +162,73 @@ def parse_case_status(raw: str) -> list[CaseInfo]:
 
     logger.info("Parsed %d/%d case status records", len(results), total)
     return results
+
+
+# ---------------------------------------------------------------------------
+# Advocate cause list — JSON-based
+# ---------------------------------------------------------------------------
+
+
+def parse_advocate_cause_list(raw: str) -> list[CauseListEntry]:
+    """Parse an advocate's cause list (``search_type=3`` from showRecords).
+
+    Shares the ``{"con": ["[{...}]"]}`` envelope with case status, but the
+    records carry listing fields that plain case status does not:
+    ``date_next_list, purpose_name, court_no, judgename``.
+
+    Two portal quirks worth knowing:
+
+    - **Rows are per-party, not per-case.** A case with seven petitioners
+      comes back as seven rows sharing one ``cino``. Callers that want cases
+      rather than parties should run :func:`dedupe_by_cnr` over the result.
+    - **``court_no`` is an internal establishment code** (e.g. "5377"), not
+      the court number shown on a display board. Join to a board on
+      ``judge`` instead.
+
+    No item/serial number is returned — that lives only in the cause list
+    PDF, so :attr:`CauseListEntry.item_number` is left empty here.
+    """
+    records, total = _parse_json_envelope(raw)
+    results = []
+    for rec in records:
+        case_no2 = str(rec.get("case_no2", ""))
+        case_year = str(rec.get("case_year", ""))
+        results.append(
+            CauseListEntry(
+                serial_number=0,
+                case_number=f"{case_no2}/{case_year}" if case_no2 and case_year else "",
+                case_type=rec.get("type_name") or "",
+                petitioner=html.unescape(rec.get("pet_name") or ""),
+                respondent=html.unescape(rec.get("res_name") or ""),
+                advocate_petitioner=html.unescape(rec.get("adv_name1") or ""),
+                advocate_respondent=html.unescape(rec.get("adv_name2") or ""),
+                court_number=str(rec.get("court_no") or ""),
+                judge=html.unescape(rec.get("judgename") or ""),
+                listing_date=_parse_date(str(rec.get("date_next_list") or "")),
+                cnr_number=rec.get("cino") or "",
+                purpose=html.unescape(rec.get("purpose_name") or ""),
+            )
+        )
+
+    logger.info("Parsed %d/%d advocate cause list rows", len(results), total)
+    return results
+
+
+def dedupe_by_cnr(entries: list[CauseListEntry]) -> list[CauseListEntry]:
+    """Collapse per-party rows into one entry per case, preserving order.
+
+    The portal repeats a case once per party, so a 39-row response can be
+    17 actual cases. The first row for each CNR is kept.
+    """
+    seen: set[str] = set()
+    out = []
+    for e in entries:
+        key = e.cnr_number or f"{e.case_type}/{e.case_number}"
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(e)
+    return out
 
 
 # ---------------------------------------------------------------------------

--- a/src/bharat_courts/models.py
+++ b/src/bharat_courts/models.py
@@ -209,6 +209,8 @@ class CauseListEntry(_Serializable):
     judge: str = ""
     listing_date: date | None = None
     item_number: str = ""
+    cnr_number: str = ""  # present on advocate cause lists, absent on PDFs
+    purpose: str = ""  # e.g. "182-FOR FINAL HEARING"
 
 
 @dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,3 +67,13 @@ def districtcourts_districts_html():
 @pytest.fixture
 def districtcourts_complexes_html():
     return (FIXTURES_DIR / "districtcourts_complexes.html").read_text()
+
+
+@pytest.fixture
+def hcservices_advocate_search_json():
+    return (FIXTURES_DIR / "hcservices_advocate_search.json").read_text()
+
+
+@pytest.fixture
+def hcservices_advocate_cause_list_json():
+    return (FIXTURES_DIR / "hcservices_advocate_cause_list.json").read_text()

--- a/tests/fixtures/hcservices_advocate_cause_list.json
+++ b/tests/fixtures/hcservices_advocate_cause_list.json
@@ -1,0 +1,24 @@
+{
+ "con": [
+  "[{\"case_type\": \"12\", \"court_no\": \"5377\", \"todays_date\": \"2026-08-13\", \"type_name\": \"FA\", \"desgname\": \"JUDGE, HIGH COURT OF GUJARAT\", \"desgcode\": \"112\", \"jcode\": \"1038\", \"judgename\": \"HONOURABLE MR.JUSTICE A B EXAMPLE\", \"lpurpose_name\": \"H##F\", \"lpet_name\": \"\", \"lres_name\": \"\", \"party_name1\": \"N\", \"party_name2\": \"N\", \"ladv_name1\": \"\", \"ladv_name2\": \"\", \"date_of_decision\": \"None\", \"orderurlpath\": \"Zz1\", \"cino\": \"GJHC240200012026\", \"case_no\": \"201200020012026\", \"case_year\": \"2026\", \"case_no2\": 2001, \"pet_name\": \"ABC INDUSTRIES LTD\", \"res_name\": \"STATE OF GUJARAT\", \"adv_name1\": \"MS. PRIYA SHARMA(1234)\", \"adv_name2\": \"GOVERNMENT PLEADER(1)\", \"date_next_list\": \"2026-08-17\", \"purpose_next\": \"1181\", \"purpose_name\": \"181-FOR FINAL DISPOSAL\"}, {\"case_type\": \"12\", \"court_no\": \"5377\", \"todays_date\": \"2026-08-13\", \"type_name\": \"FA\", \"desgname\": \"JUDGE, HIGH COURT OF GUJARAT\", \"desgcode\": \"112\", \"jcode\": \"1038\", \"judgename\": \"HONOURABLE MR.JUSTICE A B EXAMPLE\", \"lpurpose_name\": \"H##F\", \"lpet_name\": \"\", \"lres_name\": \"\", \"party_name1\": \"N\", \"party_name2\": \"N\", \"ladv_name1\": \"\", \"ladv_name2\": \"\", \"date_of_decision\": \"None\", \"orderurlpath\": \"Zz2\", \"cino\": \"GJHC240200022025\", \"case_no\": \"201200020022025\", \"case_year\": \"2025\", \"case_no2\": 2002, \"pet_name\": \"FIRST PETITIONER\", \"res_name\": \"XYZ ENTERPRISES PVT LTD\", \"adv_name1\": \"MS. PRIYA SHARMA(1234)\", \"adv_name2\": \"NOTICE UNSERVED(8)\", \"date_next_list\": \"2026-08-17\", \"purpose_next\": \"1192\", \"purpose_name\": \"192-NOTICE & ADJOURNED MATTERS\"}, {\"case_type\": \"12\", \"court_no\": \"5377\", \"todays_date\": \"2026-08-13\", \"type_name\": \"FA\", \"desgname\": \"JUDGE, HIGH COURT OF GUJARAT\", \"desgcode\": \"112\", \"jcode\": \"1038\", \"judgename\": \"HONOURABLE MR.JUSTICE A B EXAMPLE\", \"lpurpose_name\": \"H##F\", \"lpet_name\": \"\", \"lres_name\": \"\", \"party_name1\": \"N\", \"party_name2\": \"N\", \"ladv_name1\": \"\", \"ladv_name2\": \"\", \"date_of_decision\": \"None\", \"orderurlpath\": \"Zz2\", \"cino\": \"GJHC240200022025\", \"case_no\": \"201200020022025\", \"case_year\": \"2025\", \"case_no2\": 2002, \"pet_name\": \"SECOND PETITIONER\", \"res_name\": \"\", \"adv_name1\": \"MS. PRIYA SHARMA(1234)\", \"adv_name2\": \"\", \"date_next_list\": \"2026-08-17\", \"purpose_next\": \"1192\", \"purpose_name\": \"192-NOTICE & ADJOURNED MATTERS\"}, {\"case_type\": \"12\", \"court_no\": \"5351\", \"todays_date\": \"2026-08-13\", \"type_name\": \"FA\", \"desgname\": \"JUDGE, HIGH COURT OF GUJARAT\", \"desgcode\": \"112\", \"jcode\": \"1038\", \"judgename\": \"HONOURABLE MR.JUSTICE A B EXAMPLE\", \"lpurpose_name\": \"H##F\", \"lpet_name\": \"\", \"lres_name\": \"\", \"party_name1\": \"N\", \"party_name2\": \"N\", \"ladv_name1\": \"\", \"ladv_name2\": \"\", \"date_of_decision\": \"None\", \"orderurlpath\": \"Zz3\", \"cino\": \"GJHC240200032024\", \"case_no\": \"201200020032024\", \"case_year\": \"2024\", \"case_no2\": 2003, \"pet_name\": \"THIRD PARTY LTD\", \"res_name\": \"STATE OF GUJARAT\", \"adv_name1\": \"MS. PRIYA SHARMA(1234)\", \"adv_name2\": \"GOVERNMENT PLEADER(1)\", \"date_next_list\": \"2026-08-24\", \"purpose_next\": \"1182\", \"purpose_name\": \"182-FOR FINAL HEARING\"}]"
+ ],
+ "totRecords": 4,
+ "cntEst2": null,
+ "courtNameArr": [
+  "Gujarat High Court"
+ ],
+ "court_code": [
+  "1"
+ ],
+ "totEstCnt": [
+  1
+ ],
+ "adv_name": "PRIYA SHARMA",
+ "normalVArr": [
+  "1"
+ ],
+ "hide_partyname_estArr": [
+  "N"
+ ],
+ "Error": ""
+}

--- a/tests/fixtures/hcservices_advocate_search.json
+++ b/tests/fixtures/hcservices_advocate_search.json
@@ -1,0 +1,24 @@
+{
+ "con": [
+  "[{\"orderurlpath\": \"AbCdEf1\", \"cino\": \"GJHC240100012024\", \"case_no\": \"201200010012024\", \"case_type\": \"12\", \"case_year\": \"2024\", \"case_no2\": 1001, \"pet_name\": \"ABC INDUSTRIES LTD\", \"res_name\": \"STATE OF GUJARAT\", \"lpet_name\": \"\", \"lres_name\": \"\", \"party_name1\": \"N\", \"party_name2\": \"N\", \"adv_name1\": \"MS. PRIYA SHARMA(1234)\", \"adv_name2\": \"GOVERNMENT PLEADER(1)\", \"ladv_name1\": \"\", \"ladv_name2\": \"\", \"date_of_decision\": \"None\", \"type_name\": \"FA\"}, {\"orderurlpath\": \"AbCdEf2\", \"cino\": \"GJHC240100022023\", \"case_no\": \"201200010022023\", \"case_type\": \"12\", \"case_year\": \"2023\", \"case_no2\": 1002, \"pet_name\": \"XYZ ENTERPRISES PVT LTD\", \"res_name\": \"NATIONAL INSURANCE COMPANY\", \"lpet_name\": \"None\", \"lres_name\": \"None\", \"party_name1\": \"N\", \"party_name2\": \"N\", \"adv_name1\": \"MS. PRIYA SHARMA(1234)\", \"adv_name2\": \"MR. A B MEHTA(5678)\", \"ladv_name1\": \"None\", \"ladv_name2\": \"None\", \"date_of_decision\": \"2025-10-21\", \"type_name\": \"FA\"}]"
+ ],
+ "totRecords": 2,
+ "cntEst2": null,
+ "courtNameArr": [
+  "Gujarat High Court"
+ ],
+ "court_code": [
+  "1"
+ ],
+ "totEstCnt": [
+  1
+ ],
+ "adv_name": "PRIYA SHARMA",
+ "normalVArr": [
+  "1"
+ ],
+ "hide_partyname_estArr": [
+  "N"
+ ],
+ "Error": ""
+}

--- a/tests/test_hcservices_client.py
+++ b/tests/test_hcservices_client.py
@@ -9,6 +9,7 @@ from httpx import Response
 from bharat_courts.captcha.base import CaptchaSolver
 from bharat_courts.config import BharatCourtsConfig
 from bharat_courts.courts import get_court
+from bharat_courts.hcservices import endpoints
 from bharat_courts.hcservices.client import HCServicesClient
 from bharat_courts.hcservices.endpoints import (
     CAPTCHA_IMAGE_URL,
@@ -54,3 +55,51 @@ async def test_case_status(fast_config, captcha_solver):
     assert len(results) == 2
     assert results[0].case_number == "WP(C)/12345/2024"
     assert results[0].court_name == "Delhi High Court"
+
+
+# ------------------------------------------------------------------
+# Advocate form builders
+# ------------------------------------------------------------------
+
+
+def test_advocate_form_by_name():
+    form = endpoints.case_status_by_advocate_form(
+        state_code="17", captcha="abc123", advocate_name="PRIYA SHARMA"
+    )
+    assert form["caseStatusSearchType"] == "CSAdvName"
+    assert form["search_type"] == "1"
+    assert form["advocate_name"] == "PRIYA SHARMA"
+    assert "adv_bar_state" not in form
+
+
+def test_advocate_form_by_bar_code():
+    form = endpoints.case_status_by_advocate_form(
+        state_code="17", captcha="abc123", bar_code="G/504/2011"
+    )
+    # NOT CSAdvNamebar -- sending that makes the server return ERROR_VAL
+    assert form["caseStatusSearchType"] == "CSAdvName"
+    assert form["search_type"] == "2"
+    assert form["adv_bar_state"] == "G/504/2011"
+    assert "advocate_name" not in form
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"advocate_name": "PRIYA SHARMA", "bar_code": "G/504/2011"},
+    ],
+)
+def test_advocate_form_requires_exactly_one_selector(kwargs):
+    with pytest.raises(ValueError):
+        endpoints.case_status_by_advocate_form(state_code="17", captcha="abc123", **kwargs)
+
+
+def test_advocate_cause_list_form():
+    form = endpoints.advocate_cause_list_form(
+        state_code="17", captcha="abc123", bar_code="G/504/2011", causelist_date="17-08-2026"
+    )
+    assert form["search_type"] == "3"
+    assert form["f"] == "date_case_list"
+    assert form["caselist_date_dmy"] == "17-08-2026"
+    assert form["adv_bar_state"] == "G/504/2011"

--- a/tests/test_hcservices_parser.py
+++ b/tests/test_hcservices_parser.py
@@ -6,6 +6,8 @@ import pytest
 
 from bharat_courts.hcservices.parser import (
     CaptchaError,
+    dedupe_by_cnr,
+    parse_advocate_cause_list,
     parse_case_status,
     parse_cause_list,
     parse_orders,
@@ -182,3 +184,63 @@ def test_parse_cause_list(hcservices_cause_list_html):
 
 def test_parse_cause_list_empty():
     assert parse_cause_list("<html></html>") == []
+
+
+# ------------------------------------------------------------------
+# Advocate search / advocate cause list
+# ------------------------------------------------------------------
+
+
+def test_parse_advocate_search_reuses_case_status(hcservices_advocate_search_json):
+    """Advocate search returns the same envelope as any other case search."""
+    results = parse_case_status(hcservices_advocate_search_json)
+    assert len(results) == 2
+
+    first = results[0]
+    assert first.cnr_number == "GJHC240100012024"
+    assert first.case_number == "1001/2024"
+    assert first.case_type == "FA"
+    assert first.petitioner == "ABC INDUSTRIES LTD"
+    # showRecords never populates status, whatever the search mode
+    assert first.status == ""
+
+
+def test_parse_advocate_cause_list(hcservices_advocate_cause_list_json):
+    entries = parse_advocate_cause_list(hcservices_advocate_cause_list_json)
+    # four rows, because the portal repeats a case once per party
+    assert len(entries) == 4
+
+    first = entries[0]
+    assert first.cnr_number == "GJHC240200012026"
+    assert first.case_number == "2001/2026"
+    assert first.case_type == "FA"
+    assert first.petitioner == "ABC INDUSTRIES LTD"
+    assert first.advocate_petitioner == "MS. PRIYA SHARMA(1234)"
+    assert first.purpose == "181-FOR FINAL DISPOSAL"
+    assert first.judge == "HONOURABLE MR.JUSTICE A B EXAMPLE"
+    # date_next_list arrives as ISO, unlike most portal dates
+    assert first.listing_date == date(2026, 8, 17)
+    # court_no is an internal establishment code, not a display-board number
+    assert first.court_number == "5377"
+    # no serial number is returned by this endpoint
+    assert first.item_number == ""
+    assert first.serial_number == 0
+
+
+def test_parse_advocate_cause_list_dedupe(hcservices_advocate_cause_list_json):
+    """Rows 2 and 3 share a CNR; dedupe collapses them to one case."""
+    entries = parse_advocate_cause_list(hcservices_advocate_cause_list_json)
+    cases = dedupe_by_cnr(entries)
+    assert len(cases) == 3
+    assert [c.cnr_number for c in cases] == [
+        "GJHC240200012026",
+        "GJHC240200022025",
+        "GJHC240200032024",
+    ]
+    # first row per CNR wins, so the first petitioner is kept
+    assert cases[1].petitioner == "FIRST PETITIONER"
+
+
+def test_advocate_cause_list_empty_envelope():
+    entries = parse_advocate_cause_list('{"con": [], "totRecords": 0, "Error": ""}')
+    assert entries == []


### PR DESCRIPTION
Adds the two HC Services advocate endpoints, verified live against Gujarat High Court:

- case_status_by_advocate(court, advocate_name=... | bar_code=...)
- advocate_cause_list(court, bar_code=..., causelist_date=...)

Both are the advocate branch of showRecords, selected by search_type (1 = name, 2 = bar code, 3 = cause list for a date).

Two portal quirks are documented at the call sites because they are not discoverable from the markup:

- caseStatusSearchType must be "CSAdvName" for all three modes. The portal also defines a CSAdvNamebar label, but sending it as the search type makes the server answer ERROR_VAL.
- Bar codes are <STATE>/<NUMBER>/<YEAR> (e.g. "G/504/2011"), which is not the bracketed id shown beside advocate names in results.

Advocate search reuses parse_case_status unchanged -- it shares the JSON envelope with every other case search. The cause list needs its own parser because the records carry date_next_list, purpose_name, court_no and judgename, so CauseListEntry gains cnr_number and purpose (both defaulted, so existing callers are unaffected).

Rows are returned one per party rather than one per case, so a dedupe_by_cnr helper is included; a 39-row response in testing was 17 actual cases.

_parse_date now falls back to ISO because date_next_list arrives as YYYY-MM-DD while the rest of the portal uses DD-MM-YYYY.

Fixtures are synthesised from the shape of live responses rather than copied, to keep a named advocate's case list out of the repo.