### PR TITLE
feat: case lookup by CNR, and three parser fixes found against live cases

### DIFF
--- a/src/bharat_courts/__init__.py
+++ b/src/bharat_courts/__init__.py
@@ -3,6 +3,7 @@
 from bharat_courts._version import __version__
 from bharat_courts.calcuttahc.client import CalcuttaHCClient
 from bharat_courts.captcha import CaptchaSolver, ManualCaptchaSolver, default_solver
+from bharat_courts.casedetail import parse_case_detail
 from bharat_courts.config import BharatCourtsConfig, config
 from bharat_courts.courts import (
     ALL_COURTS,
@@ -21,19 +22,28 @@ from bharat_courts.hcservices.parser import CaptchaError
 from bharat_courts.http import RateLimitedClient
 from bharat_courts.judgments.client import JudgmentSearchClient
 from bharat_courts.models import (
+    ActEntry,
+    CaseDetail,
     CaseInfo,
     CaseOrder,
     CauseListEntry,
     CauseListPDF,
     Court,
     CourtType,
+    HearingEntry,
     Judgment,
     JudgmentResult,
+    PartyEntry,
     SearchResult,
 )
 from bharat_courts.sci.client import SCIClient
 
 __all__ = [
+    "parse_case_detail",
+    "PartyEntry",
+    "HearingEntry",
+    "CaseDetail",
+    "ActEntry",
     "__version__",
     "ALL_COURTS",
     "BharatCourtsConfig",

--- a/src/bharat_courts/casedetail.py
+++ b/src/bharat_courts/casedetail.py
@@ -1,0 +1,305 @@
+"""Shared parser for the full case page returned by a CNR lookup.
+
+Both portals answer a CNR search with the same *page*, not the JSON envelope
+that case searches use:
+
+- High Court (``hcservices``) returns the HTML directly.
+- District (``ecourtindia_v6``) returns JSON with the HTML in ``casetype_list``.
+
+The markup is close enough to share one parser. Where it differs it differs in
+column count rather than in structure, so layout is detected from the row
+shape instead of a portal flag:
+
+- history rows are 5 columns on High Court (cause list type, judge, business
+  date, hearing date, purpose) and 4 on district (no cause list type);
+- order rows are 5 columns on High Court (number, order-on, judge, date,
+  details) and 3 on district (number, date, details).
+
+Two traps the class names set:
+
+- the acts table is ``Acts_table`` on High Court and ``acts_table`` on
+  district, so class matching has to be case-insensitive;
+- ``transfer_table`` means *Document Details* on High Court but *case
+  transfers* on district, so it is matched by heading, never by class.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import date, datetime
+
+from bs4 import BeautifulSoup, Tag
+
+from bharat_courts.models import ActEntry, CaseDetail, CaseOrder, HearingEntry, PartyEntry
+
+logger = logging.getLogger(__name__)
+
+#: "08th September 2026" — used by the Case Status block on both portals.
+_LONG_DATE_RE = re.compile(r"(\d{1,2})(?:st|nd|rd|th)?\s+([A-Za-z]+)\s+(\d{4})")
+
+#: Party blocks read "1) NAME" then an optional "Advocate- X, Y" line.
+#: The numbering cannot be anchored to line starts: the markup uses malformed
+#: ``</br>`` tags, so entries often run together ("...R.A.SHARMA7)  ALTAF").
+#: The lookbehind keeps bar-council numbers from being mistaken for numbering —
+#: "PLEADER(1)" is preceded by "(" and "PATEL(3802)" by a digit, so neither
+#: splits, while "SHARMA7)" does.
+_PARTY_SPLIT_RE = re.compile(r"(?<![\d(])\d{1,3}\)\s*")
+_ADVOCATE_RE = re.compile(r"^advocate\s*[-:]?\s*", re.I)
+
+_NULLISH = {"", "-", "--", "none", "null", "na", "n/a"}
+
+
+def _text(node: Tag | None) -> str:
+    if node is None:
+        return ""
+    return re.sub(r"\s+", " ", node.get_text(" ", strip=True)).strip()
+
+
+def parse_flexible_date(raw: str) -> date | None:
+    """Parse the several date shapes these pages mix.
+
+    The Case Details block uses ``DD-MM-YYYY`` while Case Status spells dates
+    out ("08th September 2026"), and some fields arrive ISO.
+    """
+    text = (raw or "").strip()
+    if text.lower() in _NULLISH:
+        return None
+
+    for fmt in ("%d-%m-%Y", "%Y-%m-%d", "%d/%m/%Y"):
+        try:
+            return datetime.strptime(text, fmt).date()
+        except ValueError:
+            pass
+
+    m = _LONG_DATE_RE.search(text)
+    if m:
+        day, month, year = m.groups()
+        for fmt in ("%d %B %Y", "%d %b %Y"):
+            try:
+                return datetime.strptime(f"{day} {month} {year}", fmt).date()
+            except ValueError:
+                pass
+
+    logger.debug("Could not parse date: %s", raw)
+    return None
+
+
+def _labelled_values(table: Tag | None) -> dict[str, str]:
+    """Read a label/value table into a dict.
+
+    Rows carry either one or two label/value pairs, so cells are walked in
+    twos rather than assuming a fixed width.
+    """
+    out: dict[str, str] = {}
+    if table is None:
+        return out
+    for row in table.find_all("tr"):
+        cells = row.find_all(["th", "td"])
+        for i in range(0, len(cells) - 1, 2):
+            label = _text(cells[i]).rstrip(":").strip()
+            value = _text(cells[i + 1])
+            if label:
+                out[label.lower()] = value
+    return out
+
+
+def _table_after_heading(soup: BeautifulSoup, heading: str) -> Tag | None:
+    """Find the first table following a heading whose text matches."""
+    node = soup.find(string=lambda s: bool(s) and s.strip().lower() == heading.lower())
+    if node is None:
+        return None
+    parent = node.find_parent()
+    return parent.find_next("table") if parent else None
+
+
+def _parties(soup: BeautifulSoup, css_class: str) -> list[PartyEntry]:
+    """Parse a petitioner/respondent block.
+
+    Both portals tag these with the same class but different elements — a
+    ``<span>`` on High Court, a ``<ul>`` on district — so the class is matched
+    and the element type ignored. Entries are separated by "1)", "2)" … and an
+    advocate line is optional: unrepresented parties simply have none.
+    """
+    node = soup.find(class_=css_class)
+    if node is None:
+        return []
+
+    # <br> carries the line structure here; turn it into real newlines.
+    for br in node.find_all("br"):
+        br.replace_with("\n")
+    raw = node.get_text("\n")
+    raw = raw.replace("\xa0", " ")
+
+    entries: list[PartyEntry] = []
+    for chunk in _PARTY_SPLIT_RE.split(raw):
+        lines = [ln.strip() for ln in chunk.splitlines() if ln.strip()]
+        if not lines:
+            continue
+        name, advocate = "", ""
+        for line in lines:
+            if _ADVOCATE_RE.match(line):
+                advocate = _ADVOCATE_RE.sub("", line).strip()
+            elif not name:
+                name = line
+        if name:
+            entries.append(PartyEntry(name=name, advocate=advocate))
+    return entries
+
+
+def _acts(soup: BeautifulSoup) -> list[ActEntry]:
+    table = soup.find("table", class_=re.compile(r"acts_table", re.I))
+    if table is None:
+        return []
+    out = []
+    for row in table.find_all("tr")[1:]:  # first row is the header
+        cells = row.find_all(["td", "th"])
+        if len(cells) >= 2:
+            act = _text(cells[0])
+            if act:
+                out.append(ActEntry(act=act, sections=_text(cells[1]).rstrip(",")))
+    return out
+
+
+def _history(soup: BeautifulSoup) -> list[HearingEntry]:
+    """Read every history table on the page, in document order.
+
+    High Court pages carry two: "Case History on Filing Number" covers the
+    pre-registration hearings and "Case History" the rest. Both are real
+    listings, so both are included rather than picking one.
+    """
+    tables = soup.find_all("table", class_=re.compile(r"history_table", re.I))
+    if not tables:
+        return []
+    out: list[HearingEntry] = []
+    rows = [r for t in tables for r in t.find_all("tr")]
+    for row in rows:
+        cells = [_text(c) for c in row.find_all(["td", "th"])]
+        if not cells or not any(cells):
+            continue
+        # High Court prints a header row per table; district prints none.
+        joined = " ".join(cells).lower()
+        if "purpose of hearing" in joined or "cause list type" in joined:
+            continue
+        if len(cells) >= 5:
+            cause_list_type, judge, business, hearing, purpose = cells[:5]
+        elif len(cells) == 4:
+            cause_list_type = ""
+            judge, business, hearing, purpose = cells
+        else:
+            continue
+        out.append(
+            HearingEntry(
+                hearing_date=parse_flexible_date(hearing),
+                business_date=parse_flexible_date(business),
+                purpose=purpose,
+                judge=judge,
+                cause_list_type=cause_list_type,
+            )
+        )
+    return out
+
+
+def _orders(soup: BeautifulSoup, base_url: str = "") -> list[CaseOrder]:
+    table = soup.find("table", class_=re.compile(r"order_table", re.I))
+    if table is None:
+        return []
+    out = []
+    for row in table.find_all("tr")[1:]:
+        cells = row.find_all(["td", "th"])
+        values = [_text(c) for c in cells]
+        if not values or not any(values):
+            continue
+        if len(values) >= 5:
+            _num, order_on, judge, order_date = values[0], values[1], values[2], values[3]
+        elif len(values) >= 3:
+            _num, order_on, judge, order_date = values[0], "", "", values[1]
+        else:
+            continue
+        parsed = parse_flexible_date(order_date)
+        if parsed is None:
+            continue
+        link = row.find("a", href=True)
+        href = link["href"] if link else ""
+        if href and base_url and href.startswith(("cases/", "/")):
+            href = base_url.rstrip("/") + "/" + href.lstrip("/")
+        out.append(
+            CaseOrder(
+                order_date=parsed,
+                order_type=order_on or "Order",
+                judge=judge,
+                pdf_url=href,
+            )
+        )
+    return out
+
+
+def parse_case_detail(html: str, *, cnr: str = "", base_url: str = "") -> CaseDetail:
+    """Parse a full case page into a :class:`CaseDetail`.
+
+    Args:
+        html: The case page markup. For district courts this is the value of
+            ``casetype_list`` from the JSON response, not the response itself.
+        cnr: CNR to fall back on when the page does not restate it. High Court
+            pages print it hyphenated ("GJHC24-046431-2025"), so the passed
+            value is preferred when available.
+        base_url: Portal base, used to absolutise relative order PDF links.
+
+    Returns:
+        A CaseDetail. Missing sections yield empty lists rather than raising —
+        a case with no orders yet is normal, not an error.
+    """
+    soup = BeautifulSoup(html, "lxml")
+
+    details = _labelled_values(soup.find("table", class_=re.compile(r"case_details_table", re.I)))
+    status = _labelled_values(_table_after_heading(soup, "Case Status"))
+
+    def pick(src: dict[str, str], *keys: str) -> str:
+        for k in keys:
+            if src.get(k):
+                return src[k]
+        return ""
+
+    page_cnr = pick(details, "cnr number").split("(")[0].strip()
+
+    case_type = pick(details, "case type")
+    if not case_type:
+        # High Court omits the field and prefixes the type onto the
+        # registration number instead, e.g. "LPA /872/2025".
+        m = re.match(r"\s*([A-Za-z][A-Za-z.\s]*?)\s*/", pick(details, "registration number"))
+        if m:
+            case_type = m.group(1).strip()
+    detail = CaseDetail(
+        cnr_number=cnr or page_cnr.replace("-", ""),
+        case_type=case_type,
+        filing_number=pick(details, "filing number"),
+        filing_date=parse_flexible_date(pick(details, "filing date")),
+        registration_number=pick(details, "registration number"),
+        registration_date=parse_flexible_date(pick(details, "registration date")),
+        first_hearing_date=parse_flexible_date(pick(status, "first hearing date")),
+        next_hearing_date=parse_flexible_date(pick(status, "next hearing date")),
+        decision_date=parse_flexible_date(
+            pick(status, "decision date", "date of decision", "case decision date")
+        ),
+        case_stage=pick(status, "case stage"),
+        status=pick(status, "case status", "status"),
+        coram=pick(status, "coram"),
+        bench_type=pick(status, "bench type"),
+        court_number_and_judge=pick(status, "court number and judge"),
+        state=pick(status, "state"),
+        district=pick(status, "district"),
+        petitioners=_parties(soup, "Petitioner_Advocate_table"),
+        respondents=_parties(soup, "Respondent_Advocate_table"),
+        acts=_acts(soup),
+        history=_history(soup),
+        orders=_orders(soup, base_url),
+    )
+
+    logger.info(
+        "Parsed case detail %s: %d parties, %d history rows, %d orders",
+        detail.cnr_number or "?",
+        len(detail.petitioners) + len(detail.respondents),
+        len(detail.history),
+        len(detail.orders),
+    )
+    return detail

--- a/src/bharat_courts/casedetail.py
+++ b/src/bharat_courts/casedetail.py
@@ -167,14 +167,25 @@ def _history(soup: BeautifulSoup) -> list[HearingEntry]:
     High Court pages carry two: "Case History on Filing Number" covers the
     pre-registration hearings and "Case History" the rest. Both are real
     listings, so both are included rather than picking one.
+
+    Both the row scan and the cell scan are scoped to their nearest ancestor,
+    because Gujarat HC nests the orders table *inside* the second history
+    table. An unqualified ``find_all("tr")`` returns the orders — header row
+    and all — as hearings, and an unqualified ``find_all(["td", "th"])`` on
+    the wrapping row pulls the nested table's cells up into it, which puts the
+    whole orders table back in the count as one more bogus five-column row.
+    Verified on GJHC240464312025: 16 real listings, and 6 rows of order links
+    reading "View" that must not become diary entries.
     """
     tables = soup.find_all("table", class_=re.compile(r"history_table", re.I))
     if not tables:
         return []
     out: list[HearingEntry] = []
-    rows = [r for t in tables for r in t.find_all("tr")]
+    rows = [r for t in tables for r in t.find_all("tr") if r.find_parent("table") is t]
     for row in rows:
-        cells = [_text(c) for c in row.find_all(["td", "th"])]
+        cells = [
+            _text(c) for c in row.find_all(["td", "th"]) if c.find_parent("tr") is row
+        ]
         if not cells or not any(cells):
             continue
         # High Court prints a header row per table; district prints none.

--- a/src/bharat_courts/districtcourts/client.py
+++ b/src/bharat_courts/districtcourts/client.py
@@ -27,9 +27,11 @@ from __future__ import annotations
 
 import logging
 import random
+import re
 
 from bharat_courts.captcha import default_solver
 from bharat_courts.captcha.base import CaptchaSolver
+from bharat_courts.casedetail import parse_case_detail
 from bharat_courts.config import BharatCourtsConfig
 from bharat_courts.config import config as default_config
 from bharat_courts.districtcourts import endpoints
@@ -43,7 +45,7 @@ from bharat_courts.districtcourts.parser import (
     parse_option_tags,
 )
 from bharat_courts.http import RateLimitedClient
-from bharat_courts.models import CaseInfo, CaseOrder, CauseListEntry
+from bharat_courts.models import CaseDetail, CaseInfo, CaseOrder, CauseListEntry
 
 logger = logging.getLogger(__name__)
 
@@ -429,6 +431,52 @@ class DistrictCourtClient:
     # ------------------------------------------------------------------
     # Case status search
     # ------------------------------------------------------------------
+
+    async def case_status_by_cnr(self, cnr: str) -> CaseDetail:
+        """Look up a case by its CNR number.
+
+        Needs no state/district/complex codes: a CNR identifies the
+        establishment on its own, so this skips the ``set_data`` court setup
+        that the other lookups require. That also means it cannot reuse
+        :meth:`_post_with_captcha_retry`, which exists to re-establish that
+        selection on every retry — the retry loop here is the same shape
+        minus the court setup.
+
+        Args:
+            cnr: 16-character CNR, e.g. "GJRJ060015282018". Hyphens and
+                spaces are stripped.
+
+        Returns:
+            A CaseDetail with the full case page: stage, judge, parties with
+            advocates, acts, hearing history and interim orders.
+
+        Raises:
+            ValueError: If the CNR is not 16 alphanumeric characters.
+            CaptchaError: If every CAPTCHA attempt failed.
+        """
+        cleaned = re.sub(r"[\s-]", "", cnr).upper()
+        if len(cleaned) != 16 or not cleaned.isalnum():
+            raise ValueError(f"CNR must be 16 alphanumeric characters, got {cnr!r}")
+
+        last_error: Exception | None = None
+        for attempt in range(5):
+            if attempt > 0:
+                logger.info("CAPTCHA retry %d/5 — new session", attempt + 1)
+            await self._init_session()
+            captcha = await self._solve_captcha()
+            form = endpoints.case_status_by_cnr_form(cnr=cleaned, captcha=captcha)
+            try:
+                result = await self._post_ajax("cnr_status/searchByCNR", form)
+            except CaptchaError as exc:
+                last_error = exc
+                logger.warning("CAPTCHA attempt %d failed", attempt + 1)
+                continue
+            html = result.get("casetype_list") or result.get("historytable") or ""
+            if html:
+                return parse_case_detail(html, cnr=cleaned, base_url=endpoints.BASE_URL)
+            last_error = CaptchaError("No case data returned")
+
+        raise last_error or CaptchaError("CNR lookup failed")
 
     async def case_status(
         self,

--- a/src/bharat_courts/districtcourts/endpoints.py
+++ b/src/bharat_courts/districtcourts/endpoints.py
@@ -251,6 +251,27 @@ def fill_case_type_form(
 # ---------------------------------------------------------------------------
 
 
+def case_status_by_cnr_form(*, cnr: str, captcha: str) -> dict[str, str]:
+    """Build form data for a CNR lookup on the district portal.
+
+    Derived from ``funViewCinoHistory()`` in ``js/searchByCNR.js``. The
+    controller action is ``cnr_status/searchByCNR``. Unlike the case-number
+    searches this needs no state/district/complex codes — a CNR identifies the
+    establishment on its own — so it also needs no ``set_data`` court setup.
+
+    The response is the usual AJAX envelope; the case page arrives as HTML in
+    ``casetype_list``.
+
+    Args:
+        cnr: 16-character CNR, no hyphens or spaces.
+        captcha: Solved CAPTCHA text.
+    """
+    return {
+        "cino": cnr.strip().upper(),
+        "fcaptcha_code": captcha,
+    }
+
+
 def case_status_by_number_form(
     *,
     state_code: str,

--- a/src/bharat_courts/hcservices/client.py
+++ b/src/bharat_courts/hcservices/client.py
@@ -229,11 +229,17 @@ class HCServicesClient:
         call returns the advocate's whole book — useful for onboarding a
         practice without entering case numbers by hand.
 
-        Name search is a substring match, so it can pull in other advocates.
-        Each result carries the acting advocates in
-        ``adv_name1``/``adv_name2`` with a bracketed court id
-        ("MR. HEMAL SHAH(6960)"); filter on that id when an exact match
-        matters. Bar-code search does not need filtering.
+        Prefer the bar code. The portal resolves it to the advocate itself
+        and echoes the resolution back in the response's ``adv_name``
+        ("G/504/2011" answered with "MR. HEMAL SHAH(6960)"), so the result is
+        exact and needs no filtering.
+
+        Name search is a substring match and can pull in other advocates.
+        **Filtering it on the bracketed court id silently loses matters**:
+        for G/504/2011 the id appears on 6,666 rows but 97 more — 64 further
+        CNRs, all filed 2015 and earlier — carry the bare name with no id at
+        all. Both searches returned the same 2,779 matters; only the
+        id-filtered subset was short.
 
         Args:
             court: Court object.

--- a/src/bharat_courts/hcservices/client.py
+++ b/src/bharat_courts/hcservices/client.py
@@ -15,9 +15,11 @@ Flow:
 from __future__ import annotations
 
 import logging
+import re
 
 from bharat_courts.captcha import default_solver
 from bharat_courts.captcha.base import CaptchaSolver
+from bharat_courts.casedetail import parse_case_detail
 from bharat_courts.config import BharatCourtsConfig
 from bharat_courts.config import config as default_config
 from bharat_courts.hcservices import endpoints
@@ -29,7 +31,14 @@ from bharat_courts.hcservices.parser import (
     parse_orders,
 )
 from bharat_courts.http import RateLimitedClient
-from bharat_courts.models import CaseInfo, CaseOrder, CauseListEntry, CauseListPDF, Court
+from bharat_courts.models import (
+    CaseDetail,
+    CaseInfo,
+    CaseOrder,
+    CauseListEntry,
+    CauseListPDF,
+    Court,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -298,6 +307,37 @@ class HCServicesClient:
 
         resp = await self._post_with_captcha_retry(endpoints.SHOW_RECORDS_URL, build_form)
         return parse_advocate_cause_list(resp.text)
+
+    async def case_status_by_cnr(self, cnr: str) -> CaseDetail:
+        """Look up a case by its CNR number.
+
+        This returns considerably more than :meth:`case_status`: the search
+        endpoints answer with identity only, leaving ``status`` and
+        ``next_hearing_date`` empty, whereas a CNR lookup returns the whole
+        case page — stage, coram, every party with advocates, the acts, the
+        full hearing history and the orders — in a single request.
+
+        Args:
+            cnr: 16-character CNR, e.g. "GJHC240464312025". Hyphens and
+                spaces are stripped.
+
+        Returns:
+            A CaseDetail. Sections the case does not have (no orders yet, no
+            acts recorded) come back empty rather than raising.
+
+        Raises:
+            ValueError: If the CNR is not 16 alphanumeric characters.
+            CaptchaError: If every CAPTCHA attempt failed.
+        """
+        cleaned = re.sub(r"[\s-]", "", cnr).upper()
+        if len(cleaned) != 16 or not cleaned.isalnum():
+            raise ValueError(f"CNR must be 16 alphanumeric characters, got {cnr!r}")
+
+        def build_form(captcha: str) -> dict:
+            return endpoints.case_status_by_cnr_form(cnr=cleaned, captcha=captcha)
+
+        resp = await self._post_with_captcha_retry(endpoints.INDEX_QRY_URL, build_form)
+        return parse_case_detail(resp.text, cnr=cleaned, base_url=endpoints.BASE_URL)
 
     async def court_orders(
         self,

--- a/src/bharat_courts/hcservices/client.py
+++ b/src/bharat_courts/hcservices/client.py
@@ -23,12 +23,13 @@ from bharat_courts.config import config as default_config
 from bharat_courts.hcservices import endpoints
 from bharat_courts.hcservices.parser import (
     CaptchaError,
+    parse_advocate_cause_list,
     parse_case_status,
     parse_cause_list,
     parse_orders,
 )
 from bharat_courts.http import RateLimitedClient
-from bharat_courts.models import CaseInfo, CaseOrder, CauseListPDF, Court
+from bharat_courts.models import CaseInfo, CaseOrder, CauseListEntry, CauseListPDF, Court
 
 logger = logging.getLogger(__name__)
 
@@ -203,6 +204,100 @@ class HCServicesClient:
         for r in results:
             r.court_name = court.name
         return results
+
+    async def case_status_by_advocate(
+        self,
+        court: Court,
+        *,
+        advocate_name: str | None = None,
+        bar_code: str | None = None,
+        bench_code: str = "1",
+        status_filter: str = "Both",
+    ) -> list[CaseInfo]:
+        """Search an advocate's cases by name or bar registration number.
+
+        Unlike :meth:`case_status_by_party` this needs no year, so a single
+        call returns the advocate's whole book — useful for onboarding a
+        practice without entering case numbers by hand.
+
+        Name search is a substring match, so it can pull in other advocates.
+        Each result carries the acting advocates in
+        ``adv_name1``/``adv_name2`` with a bracketed court id
+        ("MR. HEMAL SHAH(6960)"); filter on that id when an exact match
+        matters. Bar-code search does not need filtering.
+
+        Args:
+            court: Court object.
+            advocate_name: Advocate name, full or partial (min 3 chars).
+            bar_code: Bar registration number as ``<STATE>/<NUMBER>/<YEAR>``,
+                e.g. "G/504/2011".
+            bench_code: Bench code from :meth:`list_benches` (default "1").
+            status_filter: "Pending", "Disposed", or "Both".
+
+        Returns:
+            List of matching CaseInfo objects. Results are one row per
+            party, so a case with several petitioners repeats.
+
+        Raises:
+            ValueError: If neither or both of advocate_name / bar_code given.
+        """
+
+        def build_form(captcha: str) -> dict:
+            return endpoints.case_status_by_advocate_form(
+                state_code=court.state_code,
+                court_code=bench_code,
+                captcha=captcha,
+                advocate_name=advocate_name,
+                bar_code=bar_code,
+                status_filter=status_filter,
+            )
+
+        resp = await self._post_with_captcha_retry(endpoints.SHOW_RECORDS_URL, build_form)
+        results = parse_case_status(resp.text)
+        for r in results:
+            r.court_name = court.name
+        return results
+
+    async def advocate_cause_list(
+        self,
+        court: Court,
+        *,
+        bar_code: str,
+        causelist_date: str,
+        bench_code: str = "1",
+    ) -> list[CauseListEntry]:
+        """Fetch an advocate's cause list for a given date.
+
+        This is the court's own answer to "what do I have on this date",
+        so it needs no matching against a party or advocate name.
+
+        Rows are per-party; pass the result through
+        :func:`~bharat_courts.hcservices.parser.dedupe_by_cnr` for one entry
+        per case. No item/serial number is returned — that appears only in
+        the cause list PDF.
+
+        Args:
+            court: Court object.
+            bar_code: Bar registration number, e.g. "G/504/2011".
+            causelist_date: Listing date as ``DD-MM-YYYY``. The portal
+                rejects dates more than one month ahead.
+            bench_code: Bench code from :meth:`list_benches` (default "1").
+
+        Returns:
+            List of CauseListEntry, one per party per listed case.
+        """
+
+        def build_form(captcha: str) -> dict:
+            return endpoints.advocate_cause_list_form(
+                state_code=court.state_code,
+                court_code=bench_code,
+                captcha=captcha,
+                bar_code=bar_code,
+                causelist_date=causelist_date,
+            )
+
+        resp = await self._post_with_captcha_retry(endpoints.SHOW_RECORDS_URL, build_form)
+        return parse_advocate_cause_list(resp.text)
 
     async def court_orders(
         self,

--- a/src/bharat_courts/hcservices/endpoints.py
+++ b/src/bharat_courts/hcservices/endpoints.py
@@ -214,6 +214,30 @@ def advocate_cause_list_form(
     }
 
 
+def case_status_by_cnr_form(*, cnr: str, captcha: str) -> dict[str, str]:
+    """Build form data for a CNR lookup.
+
+    Derived from the portal's ``funViewCinoHistory()``. Unlike every other
+    search this takes no state or bench code — a CNR identifies the court on
+    its own — and it answers with the full case-history page rather than the
+    JSON envelope the other searches use.
+
+    Note: ``caseStatusSearchType=CNRNumber`` must accompany the action code;
+    without it the server replies ``ERROR_caseStatusSearchTypeBlank``.
+
+    Args:
+        cnr: 16-character CNR, no hyphens or spaces.
+        captcha: Solved CAPTCHA text.
+    """
+    return {
+        "cino": cnr.strip().upper(),
+        "captcha": captcha,
+        "appFlag": "web",
+        "action_code": "fetchStateDistCourtNew",
+        "caseStatusSearchType": "CNRNumber",
+    }
+
+
 def court_orders_form(
     *,
     state_code: str,

--- a/src/bharat_courts/hcservices/endpoints.py
+++ b/src/bharat_courts/hcservices/endpoints.py
@@ -122,6 +122,98 @@ def case_status_by_party_form(
     }
 
 
+def case_status_by_advocate_form(
+    *,
+    state_code: str,
+    court_code: str = "1",
+    captcha: str,
+    advocate_name: str | None = None,
+    bar_code: str | None = None,
+    status_filter: str = "Both",
+) -> dict[str, str]:
+    """Build form data for case status search by advocate name or bar code.
+
+    Derived from the portal's advocate branch of ``funShowRecords()``. The
+    radio group ``radAdvt`` selects the mode and the JS maps it to a
+    ``search_type`` value: 1 = advocate name, 2 = bar registration number.
+
+    Note: ``caseStatusSearchType`` is ``CSAdvName`` for **both** modes. The
+    portal also defines a ``CSAdvNamebar`` label, but sending it as the
+    search type makes the server return ERROR_VAL — ``search_type`` is what
+    selects name vs bar code.
+
+    Args:
+        state_code: HC state code from courts registry.
+        court_code: Bench code from fillHCBench (default "1" = principal).
+        captcha: Solved CAPTCHA text.
+        advocate_name: Advocate name, full or partial (min 3 chars).
+        bar_code: Bar registration number as ``<STATE>/<NUMBER>/<YEAR>``,
+            e.g. "G/504/2011". Note this is *not* the bracketed id shown
+            beside advocate names in results ("MR. HEMAL SHAH(6960)"); that
+            is an internal court id.
+        status_filter: "Pending", "Disposed", or "Both".
+
+    Raises:
+        ValueError: If neither or both of advocate_name / bar_code are given.
+    """
+    if bool(advocate_name) == bool(bar_code):
+        raise ValueError("pass exactly one of advocate_name or bar_code")
+
+    form = {
+        "court_code": court_code,
+        "state_code": state_code,
+        "court_complex_code": court_code,
+        "caseStatusSearchType": "CSAdvName",
+        "captcha": captcha,
+        "f": status_filter,
+    }
+    if advocate_name:
+        form["advocate_name"] = advocate_name
+        form["search_type"] = "1"
+    else:
+        form["adv_bar_state"] = bar_code or ""
+        form["search_type"] = "2"
+    return form
+
+
+def advocate_cause_list_form(
+    *,
+    state_code: str,
+    court_code: str = "1",
+    captcha: str,
+    bar_code: str,
+    causelist_date: str,
+) -> dict[str, str]:
+    """Build form data for an advocate's cause list on a given date.
+
+    This is ``search_type=3`` of the same advocate branch. Unlike the two
+    search modes it takes a fixed ``f=date_case_list`` rather than a
+    pending/disposed filter, and it requires a bar code — advocate name is
+    not accepted for this mode.
+
+    Note: the portal rejects dates more than one month ahead
+    (``checkDateInpuWithNextMonth``).
+
+    Args:
+        state_code: HC state code from courts registry.
+        court_code: Bench code from fillHCBench (default "1" = principal).
+        captcha: Solved CAPTCHA text.
+        bar_code: Bar registration number, e.g. "G/504/2011".
+        causelist_date: Listing date as ``DD-MM-YYYY``.
+    """
+    return {
+        "court_code": court_code,
+        "state_code": state_code,
+        "court_complex_code": court_code,
+        "caseStatusSearchType": "CSAdvName",
+        "captcha": captcha,
+        "adv_bar_state": bar_code,
+        "caselist_date_dmy": causelist_date,
+        "search_type": "3",
+        "f": "date_case_list",
+    }
+
+
 def court_orders_form(
     *,
     state_code: str,

--- a/src/bharat_courts/hcservices/parser.py
+++ b/src/bharat_courts/hcservices/parser.py
@@ -178,9 +178,15 @@ def parse_advocate_cause_list(raw: str) -> list[CauseListEntry]:
 
     Two portal quirks worth knowing:
 
-    - **Rows are per-party, not per-case.** A case with seven petitioners
-      comes back as seven rows sharing one ``cino``. Callers that want cases
-      rather than parties should run :func:`dedupe_by_cnr` over the result.
+    - **Rows are a cross-product of parties and judges, not one per case.**
+      Verified on GJHC240569342026, which returned **8 rows — 4 petitioners
+      by the 2 judges of a division bench**. A count of rows is not a count
+      of matters, and :func:`dedupe_by_cnr` collapses both dimensions, so the
+      judge it keeps is one of the bench rather than the coram.
+    - **Both dates are returned per row.** ``date_next_list`` is the listing
+      being queried and ``todays_date`` is when the matter was last in court
+      — so on a board fetched for 20-08-2026, ``todays_date`` read 18-08-2026.
+      They are not two names for the same day.
     - **``court_no`` is an internal establishment code** (e.g. "5377"), not
       the court number shown on a display board. Join to a board on
       ``judge`` instead.
@@ -205,6 +211,7 @@ def parse_advocate_cause_list(raw: str) -> list[CauseListEntry]:
                 court_number=str(rec.get("court_no") or ""),
                 judge=html.unescape(rec.get("judgename") or ""),
                 listing_date=_parse_date(str(rec.get("date_next_list") or "")),
+                business_date=_parse_date(str(rec.get("todays_date") or "")),
                 cnr_number=rec.get("cino") or "",
                 purpose=html.unescape(rec.get("purpose_name") or ""),
             )
@@ -215,10 +222,14 @@ def parse_advocate_cause_list(raw: str) -> list[CauseListEntry]:
 
 
 def dedupe_by_cnr(entries: list[CauseListEntry]) -> list[CauseListEntry]:
-    """Collapse per-party rows into one entry per case, preserving order.
+    """Collapse duplicate rows into one entry per case, preserving order.
 
-    The portal repeats a case once per party, so a 39-row response can be
-    17 actual cases. The first row for each CNR is kept.
+    The portal repeats a case once per party *per judge*, so a 14-row
+    response can be 4 actual matters. The first row for each CNR is kept.
+
+    Note what that discards: on a division bench the surviving row names one
+    judge, not the coram, and it names one party of several. Callers that
+    need either should group the raw rows themselves rather than use this.
     """
     seen: set[str] = set()
     out = []

--- a/src/bharat_courts/hcservices/parser.py
+++ b/src/bharat_courts/hcservices/parser.py
@@ -20,7 +20,7 @@ from datetime import date, datetime
 
 from bs4 import BeautifulSoup, Tag
 
-from bharat_courts.models import CaseInfo, CaseOrder, CauseListPDF
+from bharat_courts.models import CaseInfo, CaseOrder, CauseListEntry, CauseListPDF
 
 logger = logging.getLogger(__name__)
 
@@ -33,15 +33,21 @@ DATE_FORMAT = "%d-%m-%Y"
 
 
 def _parse_date(text: str) -> date | None:
-    """Parse DD-MM-YYYY date string."""
+    """Parse a portal date string.
+
+    Most endpoints use DD-MM-YYYY, but the advocate cause list returns
+    ``date_next_list`` as ISO (YYYY-MM-DD), so ISO is tried as a fallback.
+    """
     text = text.strip()
-    if not text:
+    if not text or text.lower() in {"none", "null", "-", "--"}:
         return None
-    try:
-        return datetime.strptime(text, DATE_FORMAT).date()
-    except ValueError:
-        logger.debug("Could not parse date: %s", text)
-        return None
+    for fmt in (DATE_FORMAT, "%Y-%m-%d"):
+        try:
+            return datetime.strptime(text, fmt).date()
+        except ValueError:
+            continue
+    logger.debug("Could not parse date: %s", text)
+    return None
 
 
 def _clean_text(text: str | None) -> str:
@@ -156,6 +162,73 @@ def parse_case_status(raw: str) -> list[CaseInfo]:
 
     logger.info("Parsed %d/%d case status records", len(results), total)
     return results
+
+
+# ---------------------------------------------------------------------------
+# Advocate cause list — JSON-based
+# ---------------------------------------------------------------------------
+
+
+def parse_advocate_cause_list(raw: str) -> list[CauseListEntry]:
+    """Parse an advocate's cause list (``search_type=3`` from showRecords).
+
+    Shares the ``{"con": ["[{...}]"]}`` envelope with case status, but the
+    records carry listing fields that plain case status does not:
+    ``date_next_list, purpose_name, court_no, judgename``.
+
+    Two portal quirks worth knowing:
+
+    - **Rows are per-party, not per-case.** A case with seven petitioners
+      comes back as seven rows sharing one ``cino``. Callers that want cases
+      rather than parties should run :func:`dedupe_by_cnr` over the result.
+    - **``court_no`` is an internal establishment code** (e.g. "5377"), not
+      the court number shown on a display board. Join to a board on
+      ``judge`` instead.
+
+    No item/serial number is returned — that lives only in the cause list
+    PDF, so :attr:`CauseListEntry.item_number` is left empty here.
+    """
+    records, total = _parse_json_envelope(raw)
+    results = []
+    for rec in records:
+        case_no2 = str(rec.get("case_no2", ""))
+        case_year = str(rec.get("case_year", ""))
+        results.append(
+            CauseListEntry(
+                serial_number=0,
+                case_number=f"{case_no2}/{case_year}" if case_no2 and case_year else "",
+                case_type=rec.get("type_name") or "",
+                petitioner=html.unescape(rec.get("pet_name") or ""),
+                respondent=html.unescape(rec.get("res_name") or ""),
+                advocate_petitioner=html.unescape(rec.get("adv_name1") or ""),
+                advocate_respondent=html.unescape(rec.get("adv_name2") or ""),
+                court_number=str(rec.get("court_no") or ""),
+                judge=html.unescape(rec.get("judgename") or ""),
+                listing_date=_parse_date(str(rec.get("date_next_list") or "")),
+                cnr_number=rec.get("cino") or "",
+                purpose=html.unescape(rec.get("purpose_name") or ""),
+            )
+        )
+
+    logger.info("Parsed %d/%d advocate cause list rows", len(results), total)
+    return results
+
+
+def dedupe_by_cnr(entries: list[CauseListEntry]) -> list[CauseListEntry]:
+    """Collapse per-party rows into one entry per case, preserving order.
+
+    The portal repeats a case once per party, so a 39-row response can be
+    17 actual cases. The first row for each CNR is kept.
+    """
+    seen: set[str] = set()
+    out = []
+    for e in entries:
+        key = e.cnr_number or f"{e.case_type}/{e.case_number}"
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(e)
+    return out
 
 
 # ---------------------------------------------------------------------------

--- a/src/bharat_courts/models.py
+++ b/src/bharat_courts/models.py
@@ -286,6 +286,11 @@ class CauseListEntry(_Serializable):
     court_number: str = ""
     judge: str = ""
     listing_date: date | None = None
+    #: The day the matter was last in court, where the source gives it. The
+    #: advocate cause list returns both dates per row — this one and the
+    #: listing being queried — and a diary needs the pair to tell an
+    #: adjournment from the hearing that produced it.
+    business_date: date | None = None
     item_number: str = ""
     cnr_number: str = ""  # present on advocate cause lists, absent on PDFs
     purpose: str = ""  # e.g. "182-FOR FINAL HEARING"

--- a/src/bharat_courts/models.py
+++ b/src/bharat_courts/models.py
@@ -190,6 +190,84 @@ class Judgment(_Serializable):
 
 
 @dataclass
+class PartyEntry(_Serializable):
+    """A party to a case, with the advocate(s) appearing for them."""
+
+    name: str
+    advocate: str = ""
+
+
+@dataclass
+class ActEntry(_Serializable):
+    """An act and the sections invoked under it."""
+
+    act: str
+    sections: str = ""
+
+
+@dataclass
+class HearingEntry(_Serializable):
+    """One row of a case's hearing history.
+
+    ``cause_list_type`` and ``judge`` are only populated where the portal
+    supplies them — district court history tables carry a judge but no cause
+    list type, High Court tables carry both but often leave judge blank.
+    """
+
+    hearing_date: date | None = None
+    business_date: date | None = None
+    purpose: str = ""
+    judge: str = ""
+    cause_list_type: str = ""
+
+
+@dataclass
+class CaseDetail(_Serializable):
+    """Full case record from a CNR lookup.
+
+    This is deliberately richer than :class:`CaseInfo`, which models a search
+    *result*. A CNR lookup returns the whole case page — status, stage, the
+    bench, every party with their advocates, the acts invoked, the complete
+    hearing history and the orders — none of which a search response carries.
+
+    Fields absent from a given portal are left at their default rather than
+    guessed: district courts report ``court_number_and_judge`` where High
+    Courts report ``coram`` plus ``bench_type``.
+    """
+
+    cnr_number: str = ""
+    case_type: str = ""
+    filing_number: str = ""
+    filing_date: date | None = None
+    registration_number: str = ""
+    registration_date: date | None = None
+
+    first_hearing_date: date | None = None
+    next_hearing_date: date | None = None
+    decision_date: date | None = None
+    case_stage: str = ""
+    status: str = ""
+
+    coram: str = ""
+    bench_type: str = ""
+    court_number_and_judge: str = ""
+    court_name: str = ""
+    state: str = ""
+    district: str = ""
+
+    petitioners: list[PartyEntry] = field(default_factory=list)
+    respondents: list[PartyEntry] = field(default_factory=list)
+    acts: list[ActEntry] = field(default_factory=list)
+    history: list[HearingEntry] = field(default_factory=list)
+    orders: list[CaseOrder] = field(default_factory=list)
+
+    @property
+    def is_disposed(self) -> bool:
+        """True when the portal has recorded a decision date."""
+        return self.decision_date is not None
+
+
+@dataclass
 class CauseListEntry(_Serializable):
     """An entry from a court's cause list (daily schedule).
 

--- a/src/bharat_courts/models.py
+++ b/src/bharat_courts/models.py
@@ -209,6 +209,8 @@ class CauseListEntry(_Serializable):
     judge: str = ""
     listing_date: date | None = None
     item_number: str = ""
+    cnr_number: str = ""  # present on advocate cause lists, absent on PDFs
+    purpose: str = ""  # e.g. "182-FOR FINAL HEARING"
 
 
 @dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,3 +77,13 @@ def hcservices_advocate_search_json():
 @pytest.fixture
 def hcservices_advocate_cause_list_json():
     return (FIXTURES_DIR / "hcservices_advocate_cause_list.json").read_text()
+
+
+@pytest.fixture
+def hcservices_case_detail_html():
+    return (FIXTURES_DIR / "hcservices_case_detail.html").read_text()
+
+
+@pytest.fixture
+def districtcourts_case_detail_html():
+    return (FIXTURES_DIR / "districtcourts_case_detail.html").read_text()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,3 +67,13 @@ def districtcourts_districts_html():
 @pytest.fixture
 def districtcourts_complexes_html():
     return (FIXTURES_DIR / "districtcourts_complexes.html").read_text()
+
+
+@pytest.fixture
+def hcservices_advocate_search_json():
+    return (FIXTURES_DIR / "hcservices_advocate_search.json").read_text()
+
+
+@pytest.fixture
+def hcservices_advocate_cause_list_json():
+    return (FIXTURES_DIR / "hcservices_advocate_cause_list.json").read_text()

--- a/tests/fixtures/districtcourts_case_detail.html
+++ b/tests/fixtures/districtcourts_case_detail.html
@@ -1,0 +1,31 @@
+<html><body>
+<h2>Case Details</h2>
+<table class="table case_details_table table-bordered">
+<tr><th scope="row">Case Type</th><td>SPCS - SPECIAL CIVIL SUIT</td></tr>
+<tr><th scope="row">Filing Number</th><td>33/2018</td><th scope="row">Filing Date</th><td>29-10-2018</td></tr>
+<tr><th scope="row">Registration Number</th><td>33/2018</td><th scope="row">Registration Date</th><td>29-10-2018</td></tr>
+<tr><th scope="row">CNR Number</th><td>GJRJ060015282018 (Note the CNR number for future reference)</td></tr>
+</table>
+<h3>Case Status</h3>
+<table class="table case_status_table table-bordered">
+<tr><th scope="row">First Hearing Date</th><td>29th October 2018</td></tr>
+<tr><th scope="row">Next Hearing Date</th><td>17th August 2026</td></tr>
+<tr><th scope="row">Case Stage</th><td>PLAINTIFF EVIDENCE</td></tr>
+<tr><th scope="row">Court Number and Judge</th><td>1-PRINCIPAL SENIOR CIVIL JUDGE &amp; ADDL. CJM</td></tr>
+</table>
+<h3>Petitioner and Advocate</h3>
+<ul class="table Petitioner_Advocate_table"><li>1) FIRST PETITIONER NAME<br />&nbsp;Advocate- J R EXAMPLE<br />2)  SECOND PETITIONER NAME&nbsp;<br>&nbsp;Advocate-J R EXAMPLE</br></li></ul>
+<h3>Respondent and Advocate</h3>
+<ul class="table Respondent_Advocate_table"><li>1) FIRST RESPONDENT<br />&nbsp;Advocate - no vp<br />2)  SECOND RESPONDENT&nbsp;<br>3)  THIRD RESPONDENT&nbsp;<br>&nbsp;Advocate-A N SAMPLE</br>4)  FOURTH RESPONDENT&nbsp;<br>&nbsp;Advocate-R A SAMPLE</br></li></ul>
+<h3>Acts</h3>
+<table class="table acts_table table-bordered"><tr><th>Under Act(s)</th><th>Under Section(s)</th></tr>
+<tr><td>SPECIFIC RELIEF ACT, 1963</td><td>34,38,32,</td></tr></table>
+<h3>Case History</h3>
+<table class="history_table table">
+<tr><td>PRINCIPAL SENIOR CIVIL JUDGE</td><td>18-07-2026</td><td>17-08-2026</td><td>PLAINTIFF EVIDENCE</td></tr>
+<tr><td>PRINCIPAL SENIOR CIVIL JUDGE</td><td>11-06-2026</td><td>18-07-2026</td><td>PLAINTIFF EVIDENCE</td></tr>
+<tr><td>ADDL. SR. CIVIL JUDGE</td><td>22-10-2019</td><td>13-11-2019</td><td>HEARING ON INJUNCTION APPLICATION</td></tr></table>
+<h3>Interim Orders</h3>
+<table class="order_table table"><tr><th>Order Number</th><th>Order Date</th><th>Order Details</th></tr>
+<tr><td>1</td><td>13-11-2019</td><td><a href="/order.pdf">ORDER</a></td></tr></table>
+</body></html>

--- a/tests/fixtures/hcservices_advocate_cause_list.json
+++ b/tests/fixtures/hcservices_advocate_cause_list.json
@@ -1,0 +1,24 @@
+{
+ "con": [
+  "[{\"case_type\": \"12\", \"court_no\": \"5377\", \"todays_date\": \"2026-08-13\", \"type_name\": \"FA\", \"desgname\": \"JUDGE, HIGH COURT OF GUJARAT\", \"desgcode\": \"112\", \"jcode\": \"1038\", \"judgename\": \"HONOURABLE MR.JUSTICE A B EXAMPLE\", \"lpurpose_name\": \"H##F\", \"lpet_name\": \"\", \"lres_name\": \"\", \"party_name1\": \"N\", \"party_name2\": \"N\", \"ladv_name1\": \"\", \"ladv_name2\": \"\", \"date_of_decision\": \"None\", \"orderurlpath\": \"Zz1\", \"cino\": \"GJHC240200012026\", \"case_no\": \"201200020012026\", \"case_year\": \"2026\", \"case_no2\": 2001, \"pet_name\": \"ABC INDUSTRIES LTD\", \"res_name\": \"STATE OF GUJARAT\", \"adv_name1\": \"MS. PRIYA SHARMA(1234)\", \"adv_name2\": \"GOVERNMENT PLEADER(1)\", \"date_next_list\": \"2026-08-17\", \"purpose_next\": \"1181\", \"purpose_name\": \"181-FOR FINAL DISPOSAL\"}, {\"case_type\": \"12\", \"court_no\": \"5377\", \"todays_date\": \"2026-08-13\", \"type_name\": \"FA\", \"desgname\": \"JUDGE, HIGH COURT OF GUJARAT\", \"desgcode\": \"112\", \"jcode\": \"1038\", \"judgename\": \"HONOURABLE MR.JUSTICE A B EXAMPLE\", \"lpurpose_name\": \"H##F\", \"lpet_name\": \"\", \"lres_name\": \"\", \"party_name1\": \"N\", \"party_name2\": \"N\", \"ladv_name1\": \"\", \"ladv_name2\": \"\", \"date_of_decision\": \"None\", \"orderurlpath\": \"Zz2\", \"cino\": \"GJHC240200022025\", \"case_no\": \"201200020022025\", \"case_year\": \"2025\", \"case_no2\": 2002, \"pet_name\": \"FIRST PETITIONER\", \"res_name\": \"XYZ ENTERPRISES PVT LTD\", \"adv_name1\": \"MS. PRIYA SHARMA(1234)\", \"adv_name2\": \"NOTICE UNSERVED(8)\", \"date_next_list\": \"2026-08-17\", \"purpose_next\": \"1192\", \"purpose_name\": \"192-NOTICE & ADJOURNED MATTERS\"}, {\"case_type\": \"12\", \"court_no\": \"5377\", \"todays_date\": \"2026-08-13\", \"type_name\": \"FA\", \"desgname\": \"JUDGE, HIGH COURT OF GUJARAT\", \"desgcode\": \"112\", \"jcode\": \"1038\", \"judgename\": \"HONOURABLE MR.JUSTICE A B EXAMPLE\", \"lpurpose_name\": \"H##F\", \"lpet_name\": \"\", \"lres_name\": \"\", \"party_name1\": \"N\", \"party_name2\": \"N\", \"ladv_name1\": \"\", \"ladv_name2\": \"\", \"date_of_decision\": \"None\", \"orderurlpath\": \"Zz2\", \"cino\": \"GJHC240200022025\", \"case_no\": \"201200020022025\", \"case_year\": \"2025\", \"case_no2\": 2002, \"pet_name\": \"SECOND PETITIONER\", \"res_name\": \"\", \"adv_name1\": \"MS. PRIYA SHARMA(1234)\", \"adv_name2\": \"\", \"date_next_list\": \"2026-08-17\", \"purpose_next\": \"1192\", \"purpose_name\": \"192-NOTICE & ADJOURNED MATTERS\"}, {\"case_type\": \"12\", \"court_no\": \"5351\", \"todays_date\": \"2026-08-13\", \"type_name\": \"FA\", \"desgname\": \"JUDGE, HIGH COURT OF GUJARAT\", \"desgcode\": \"112\", \"jcode\": \"1038\", \"judgename\": \"HONOURABLE MR.JUSTICE A B EXAMPLE\", \"lpurpose_name\": \"H##F\", \"lpet_name\": \"\", \"lres_name\": \"\", \"party_name1\": \"N\", \"party_name2\": \"N\", \"ladv_name1\": \"\", \"ladv_name2\": \"\", \"date_of_decision\": \"None\", \"orderurlpath\": \"Zz3\", \"cino\": \"GJHC240200032024\", \"case_no\": \"201200020032024\", \"case_year\": \"2024\", \"case_no2\": 2003, \"pet_name\": \"THIRD PARTY LTD\", \"res_name\": \"STATE OF GUJARAT\", \"adv_name1\": \"MS. PRIYA SHARMA(1234)\", \"adv_name2\": \"GOVERNMENT PLEADER(1)\", \"date_next_list\": \"2026-08-24\", \"purpose_next\": \"1182\", \"purpose_name\": \"182-FOR FINAL HEARING\"}]"
+ ],
+ "totRecords": 4,
+ "cntEst2": null,
+ "courtNameArr": [
+  "Gujarat High Court"
+ ],
+ "court_code": [
+  "1"
+ ],
+ "totEstCnt": [
+  1
+ ],
+ "adv_name": "PRIYA SHARMA",
+ "normalVArr": [
+  "1"
+ ],
+ "hide_partyname_estArr": [
+  "N"
+ ],
+ "Error": ""
+}

--- a/tests/fixtures/hcservices_advocate_search.json
+++ b/tests/fixtures/hcservices_advocate_search.json
@@ -1,0 +1,24 @@
+{
+ "con": [
+  "[{\"orderurlpath\": \"AbCdEf1\", \"cino\": \"GJHC240100012024\", \"case_no\": \"201200010012024\", \"case_type\": \"12\", \"case_year\": \"2024\", \"case_no2\": 1001, \"pet_name\": \"ABC INDUSTRIES LTD\", \"res_name\": \"STATE OF GUJARAT\", \"lpet_name\": \"\", \"lres_name\": \"\", \"party_name1\": \"N\", \"party_name2\": \"N\", \"adv_name1\": \"MS. PRIYA SHARMA(1234)\", \"adv_name2\": \"GOVERNMENT PLEADER(1)\", \"ladv_name1\": \"\", \"ladv_name2\": \"\", \"date_of_decision\": \"None\", \"type_name\": \"FA\"}, {\"orderurlpath\": \"AbCdEf2\", \"cino\": \"GJHC240100022023\", \"case_no\": \"201200010022023\", \"case_type\": \"12\", \"case_year\": \"2023\", \"case_no2\": 1002, \"pet_name\": \"XYZ ENTERPRISES PVT LTD\", \"res_name\": \"NATIONAL INSURANCE COMPANY\", \"lpet_name\": \"None\", \"lres_name\": \"None\", \"party_name1\": \"N\", \"party_name2\": \"N\", \"adv_name1\": \"MS. PRIYA SHARMA(1234)\", \"adv_name2\": \"MR. A B MEHTA(5678)\", \"ladv_name1\": \"None\", \"ladv_name2\": \"None\", \"date_of_decision\": \"2025-10-21\", \"type_name\": \"FA\"}]"
+ ],
+ "totRecords": 2,
+ "cntEst2": null,
+ "courtNameArr": [
+  "Gujarat High Court"
+ ],
+ "court_code": [
+  "1"
+ ],
+ "totEstCnt": [
+  1
+ ],
+ "adv_name": "PRIYA SHARMA",
+ "normalVArr": [
+  "1"
+ ],
+ "hide_partyname_estArr": [
+  "N"
+ ],
+ "Error": ""
+}

--- a/tests/fixtures/hcservices_case_detail.html
+++ b/tests/fixtures/hcservices_case_detail.html
@@ -28,8 +28,13 @@
 <h2>Case History</h2>
 <table class="history_table"><tr><th>Cause List Type</th><th>Judge</th><th>Business on Date</th><th>Hearing Date</th><th>Purpose of Hearing</th></tr>
 <tr><td>DAILY</td><td></td><td>06-08-2026</td><td>08-09-2026</td><td>192-NOTICE &amp; ADJOURNED MATTERS</td></tr>
-<tr><td>DAILY</td><td></td><td>24-07-2026</td><td>06-08-2026</td><td>192-NOTICE &amp; ADJOURNED MATTERS</td></tr></table>
+<tr><td>DAILY</td><td></td><td>24-07-2026</td><td>06-08-2026</td><td>192-NOTICE &amp; ADJOURNED MATTERS</td></tr>
+<!-- Gujarat HC nests the orders table INSIDE the history table. Verified live
+     on GJHC240464312025, where an unqualified row scan returned 22 "hearings":
+     16 real ones plus the orders table's header and its five "View" links. -->
+<tr><td colspan="5">
 <h2>Orders</h2>
 <table class="order_table"><tr><th>Order Number</th><th>Order on</th><th>Judge</th><th>Order Date</th><th>Order Details</th></tr>
 <tr><td>1</td><td>LPA/872/2025</td><td>HONOURABLE MR. JUSTICE C D SAMPLE</td><td>25-07-2025</td><td><a href="cases/display_pdf.php?f=xyz">View</a></td></tr></table>
+</td></tr></table>
 </body></html>

--- a/tests/fixtures/hcservices_case_detail.html
+++ b/tests/fixtures/hcservices_case_detail.html
@@ -1,0 +1,35 @@
+<html><body>
+<h2>Case Details</h2>
+<table class="table case_details_table">
+<tr><td><label>Filing Number</label></td><td>LPA /20486/2025</td><td><label>Filing Date</label></td><td>27-06-2025</td></tr>
+<tr><td><label>Registration Number</label></td><td>LPA /872/2025</td><td><label>Registration Date</label></td><td>21-07-2025</td></tr>
+<tr><td><label>CNR Number</label></td><td>GJHC24-046431-2025</td></tr>
+</table>
+<h2>Case Status</h2>
+<table class="table_r table text-left">
+<tr><td><label>First Hearing Date</label></td><td></td></tr>
+<tr><td><label>Next Hearing Date</label></td><td>08th September 2026</td></tr>
+<tr><td><label>Case Stage</label></td><td>192-NOTICE &amp; ADJOURNED MATTERS</td></tr>
+<tr><td><label>Coram</label></td><td>HONOURABLE MR.JUSTICE A B EXAMPLE</td></tr>
+<tr><td><label>Bench Type</label></td><td>DIVISION</td></tr>
+<tr><td><label>State</label></td><td>GUJARAT</td></tr>
+<tr><td><label>District</label></td><td>BHAVNAGAR</td></tr>
+</table>
+<h2>Petitioner and Advocate</h2>
+<span class="Petitioner_Advocate_table">1) ABC INDUSTRIES LTD<br />&nbsp;&nbsp;Advocate- MS. PRIYA SHARMA(1234),EXAMPLE LAW OFFICES(5678)<br /></span>
+<h2>Respondent and Advocate</h2>
+<span class="Respondent_Advocate_table">1) FIRST RESPONDENT BANK<br />&nbsp;&nbsp;Advocate - NOTICE THROUGH RPAD NOT RECEIVED BACK<br> &nbsp; <br />  2)  REGIONAL MANAGER, FIRST RESPONDENT BANK<br>&nbsp;&nbsp;Advocate-MR. A B MEHTA(3802)</br>3)  BRANCH MANAGER, FIRST RESPONDENT BANK<br>&nbsp;&nbsp;Advocate-MR. A B MEHTA(3802)</br></span>
+<h2>Acts</h2>
+<table class="Acts_table"><tr><th>Under Act(s)</th><th>Under Section(s)</th></tr>
+<tr><td>LETTERS PATENT, 1865</td><td>15</td></tr></table>
+<h2>Case History on Filing Number</h2>
+<table class="history_table"><tr><th>Cause List Type</th><th>Judge</th><th>Business on Date</th><th>Hearing Date</th><th>Purpose of Hearing</th></tr>
+<tr><td>OFFICE OBJECTIONS BOARD</td><td>ADDITIONAL REGISTRAR</td><td></td><td>11-07-2025</td><td>3600-FRESH MATTERS</td></tr></table>
+<h2>Case History</h2>
+<table class="history_table"><tr><th>Cause List Type</th><th>Judge</th><th>Business on Date</th><th>Hearing Date</th><th>Purpose of Hearing</th></tr>
+<tr><td>DAILY</td><td></td><td>06-08-2026</td><td>08-09-2026</td><td>192-NOTICE &amp; ADJOURNED MATTERS</td></tr>
+<tr><td>DAILY</td><td></td><td>24-07-2026</td><td>06-08-2026</td><td>192-NOTICE &amp; ADJOURNED MATTERS</td></tr></table>
+<h2>Orders</h2>
+<table class="order_table"><tr><th>Order Number</th><th>Order on</th><th>Judge</th><th>Order Date</th><th>Order Details</th></tr>
+<tr><td>1</td><td>LPA/872/2025</td><td>HONOURABLE MR. JUSTICE C D SAMPLE</td><td>25-07-2025</td><td><a href="cases/display_pdf.php?f=xyz">View</a></td></tr></table>
+</body></html>

--- a/tests/test_casedetail.py
+++ b/tests/test_casedetail.py
@@ -86,6 +86,23 @@ def test_hc_reads_both_history_tables(hcservices_case_detail_html):
     assert all(h.purpose != "Purpose of Hearing" for h in d.history)
 
 
+# Regression: Gujarat HC nests the orders table inside the history table, so
+# an unqualified row scan swallowed it whole — GJHC240464312025 came back with
+# 22 "hearings" instead of 16, the extra six being the orders header and five
+# rows whose purpose read "View". Every one of those would have become a diary
+# entry. Rows now count only where the history table is their nearest ancestor.
+def test_hc_history_excludes_the_nested_orders_table(hcservices_case_detail_html):
+    detail = parse_case_detail(hcservices_case_detail_html)
+    purposes = [h.purpose for h in detail.history]
+    assert "View" not in purposes, f"orders leaked into history: {purposes}"
+    assert "Order Details" not in purposes
+    assert all(h.hearing_date is not None for h in detail.history)
+    # One row from "Case History on Filing Number", two from "Case History".
+    assert len(detail.history) == 3
+    # And the orders themselves are still found, from their own table.
+    assert len(detail.orders) == 1
+
+
 def test_hc_acts_and_orders(hcservices_case_detail_html):
     d = parse_case_detail(
         hcservices_case_detail_html, base_url="https://hcservices.ecourts.gov.in/hcservices"

--- a/tests/test_casedetail.py
+++ b/tests/test_casedetail.py
@@ -1,0 +1,166 @@
+"""Tests for the shared CNR case-detail parser.
+
+The two portals return the same page shape with different column counts and
+inconsistent class-name casing, so both are exercised against the same parser.
+"""
+
+from datetime import date
+
+import pytest
+
+from bharat_courts.casedetail import parse_case_detail, parse_flexible_date
+
+# ------------------------------------------------------------------
+# Date handling — these pages mix three formats
+# ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("27-06-2025", date(2025, 6, 27)),
+        ("2026-08-17", date(2026, 8, 17)),
+        ("08th September 2026", date(2026, 9, 8)),
+        ("29th October 2018", date(2018, 10, 29)),
+        ("1 March 2020", date(2020, 3, 1)),
+        ("", None),
+        ("--", None),
+        ("None", None),
+        ("not a date", None),
+    ],
+)
+def test_parse_flexible_date(raw, expected):
+    assert parse_flexible_date(raw) == expected
+
+
+# ------------------------------------------------------------------
+# High Court page
+# ------------------------------------------------------------------
+
+
+def test_hc_case_detail_core(hcservices_case_detail_html):
+    d = parse_case_detail(hcservices_case_detail_html, cnr="GJHC240464312025")
+
+    assert d.cnr_number == "GJHC240464312025"
+    # HC has no Case Type row; it is derived from the registration number
+    assert d.case_type == "LPA"
+    assert d.filing_number == "LPA /20486/2025"
+    assert d.filing_date == date(2025, 6, 27)
+    assert d.registration_date == date(2025, 7, 21)
+
+    # the fields plain case search leaves empty
+    assert d.next_hearing_date == date(2026, 9, 8)
+    assert d.case_stage == "192-NOTICE & ADJOURNED MATTERS"
+    assert d.coram == "HONOURABLE MR.JUSTICE A B EXAMPLE"
+    assert d.bench_type == "DIVISION"
+    assert d.state == "GUJARAT"
+    assert d.first_hearing_date is None
+    assert d.is_disposed is False
+
+
+def test_hc_parties_survive_malformed_br(hcservices_case_detail_html):
+    """Entries run together across malformed </br>, and bar numbers must not
+    be mistaken for the "N)" numbering."""
+    d = parse_case_detail(hcservices_case_detail_html)
+
+    assert [p.name for p in d.petitioners] == ["ABC INDUSTRIES LTD"]
+    assert d.petitioners[0].advocate.startswith("MS. PRIYA SHARMA(1234)")
+
+    assert len(d.respondents) == 3
+    assert d.respondents[2].name == "BRANCH MANAGER, FIRST RESPONDENT BANK"
+    # "(3802)" must not split the entry
+    assert d.respondents[1].advocate == "MR. A B MEHTA(3802)"
+    # an unrepresented party simply has no advocate line
+    assert d.respondents[0].advocate == "NOTICE THROUGH RPAD NOT RECEIVED BACK"
+
+
+def test_hc_reads_both_history_tables(hcservices_case_detail_html):
+    """HC splits history across "on Filing Number" and "Case History"."""
+    d = parse_case_detail(hcservices_case_detail_html)
+    assert len(d.history) == 3
+    assert d.history[0].hearing_date == date(2025, 7, 11)
+    assert d.history[0].cause_list_type == "OFFICE OBJECTIONS BOARD"
+    assert d.history[1].hearing_date == date(2026, 9, 8)
+    assert d.history[1].business_date == date(2026, 8, 6)
+    # header rows must not leak in as hearings
+    assert all(h.purpose != "Purpose of Hearing" for h in d.history)
+
+
+def test_hc_acts_and_orders(hcservices_case_detail_html):
+    d = parse_case_detail(
+        hcservices_case_detail_html, base_url="https://hcservices.ecourts.gov.in/hcservices"
+    )
+    assert [(a.act, a.sections) for a in d.acts] == [("LETTERS PATENT, 1865", "15")]
+
+    assert len(d.orders) == 1
+    order = d.orders[0]
+    assert order.order_date == date(2025, 7, 25)
+    assert order.order_type == "LPA/872/2025"
+    assert order.judge == "HONOURABLE MR. JUSTICE C D SAMPLE"
+    assert order.pdf_url.startswith("https://hcservices.ecourts.gov.in/hcservices/cases/")
+
+
+# ------------------------------------------------------------------
+# District Court page
+# ------------------------------------------------------------------
+
+
+def test_district_case_detail_core(districtcourts_case_detail_html):
+    d = parse_case_detail(districtcourts_case_detail_html, cnr="GJRJ060015282018")
+
+    assert d.cnr_number == "GJRJ060015282018"
+    assert d.case_type == "SPCS - SPECIAL CIVIL SUIT"
+    assert d.first_hearing_date == date(2018, 10, 29)
+    assert d.next_hearing_date == date(2026, 8, 17)
+    assert d.case_stage == "PLAINTIFF EVIDENCE"
+    # district reports a combined court/judge where HC reports coram
+    assert d.court_number_and_judge == "1-PRINCIPAL SENIOR CIVIL JUDGE & ADDL. CJM"
+    assert d.coram == ""
+
+
+def test_district_cnr_strips_trailing_note(districtcourts_case_detail_html):
+    """The page appends "(Note the CNR number...)" to the value."""
+    d = parse_case_detail(districtcourts_case_detail_html)
+    assert d.cnr_number == "GJRJ060015282018"
+
+
+def test_district_parties(districtcourts_case_detail_html):
+    d = parse_case_detail(districtcourts_case_detail_html)
+    assert len(d.petitioners) == 2
+    assert len(d.respondents) == 4
+    assert d.respondents[1].name == "SECOND RESPONDENT"
+    assert d.respondents[1].advocate == ""
+    assert d.respondents[3].advocate == "R A SAMPLE"
+
+
+def test_district_history_has_no_header_row(districtcourts_case_detail_html):
+    """District history tables are 4 columns with no header."""
+    d = parse_case_detail(districtcourts_case_detail_html)
+    assert len(d.history) == 3
+    first = d.history[0]
+    assert first.hearing_date == date(2026, 8, 17)
+    assert first.business_date == date(2026, 7, 18)
+    assert first.purpose == "PLAINTIFF EVIDENCE"
+    assert first.judge == "PRINCIPAL SENIOR CIVIL JUDGE"
+    assert first.cause_list_type == ""
+
+
+def test_district_acts_lowercase_class_and_orders(districtcourts_case_detail_html):
+    """acts_table here vs Acts_table on HC; orders are 3 columns not 5."""
+    d = parse_case_detail(districtcourts_case_detail_html)
+    assert d.acts[0].act == "SPECIFIC RELIEF ACT, 1963"
+    assert d.acts[0].sections == "34,38,32"  # trailing comma stripped
+    assert len(d.orders) == 1
+    assert d.orders[0].order_date == date(2019, 11, 13)
+    assert d.orders[0].judge == ""
+
+
+# ------------------------------------------------------------------
+# Degenerate input
+# ------------------------------------------------------------------
+
+
+def test_empty_page_yields_empty_detail():
+    d = parse_case_detail("<html><body></body></html>", cnr="GJHC240464312025")
+    assert d.cnr_number == "GJHC240464312025"
+    assert d.petitioners == [] and d.history == [] and d.orders == []

--- a/tests/test_districtcourts_client.py
+++ b/tests/test_districtcourts_client.py
@@ -637,3 +637,25 @@ async def test_invalid_request_not_retried_when_delimeter_unchanged(fast_config,
                 await client.list_districts("8")
 
     assert len(calls) == 1, "should not retry when the secret did not rotate"
+
+
+# ------------------------------------------------------------------
+# CNR lookup
+# ------------------------------------------------------------------
+
+
+def test_cnr_form():
+    from bharat_courts.districtcourts import endpoints as dc_endpoints
+
+    form = dc_endpoints.case_status_by_cnr_form(cnr="gjrj060015282018", captcha="abc123")
+    # the district portal names the captcha field differently from HC
+    assert form == {"cino": "GJRJ060015282018", "fcaptcha_code": "abc123"}
+
+
+@pytest.mark.parametrize("bad", ["", "GJRJ06001528201", "GJRJ0600152820188", "GJRJ0600152820!8"])
+async def test_cnr_lookup_rejects_malformed(bad):
+    from bharat_courts import DistrictCourtClient
+
+    client = DistrictCourtClient()
+    with pytest.raises(ValueError, match="16 alphanumeric"):
+        await client.case_status_by_cnr(bad)

--- a/tests/test_hcservices_client.py
+++ b/tests/test_hcservices_client.py
@@ -103,3 +103,31 @@ def test_advocate_cause_list_form():
     assert form["f"] == "date_case_list"
     assert form["caselist_date_dmy"] == "17-08-2026"
     assert form["adv_bar_state"] == "G/504/2011"
+
+
+# ------------------------------------------------------------------
+# CNR lookup
+# ------------------------------------------------------------------
+
+
+def test_cnr_form():
+    form = endpoints.case_status_by_cnr_form(cnr="GJHC240464312025", captcha="abc123")
+    assert form["cino"] == "GJHC240464312025"
+    assert form["action_code"] == "fetchStateDistCourtNew"
+    # without this the server answers ERROR_caseStatusSearchTypeBlank
+    assert form["caseStatusSearchType"] == "CNRNumber"
+    assert form["appFlag"] == "web"
+
+
+def test_cnr_form_normalises_case():
+    form = endpoints.case_status_by_cnr_form(cnr=" gjhc240464312025 ", captcha="x")
+    assert form["cino"] == "GJHC240464312025"
+
+
+@pytest.mark.parametrize(
+    "bad", ["", "TOO-SHORT", "GJHC24046431202", "GJHC2404643120255", "GJHC2404643120!5"]
+)
+async def test_cnr_lookup_rejects_malformed(bad):
+    client = HCServicesClient()
+    with pytest.raises(ValueError, match="16 alphanumeric"):
+        await client.case_status_by_cnr(bad)

--- a/tests/test_hcservices_client.py
+++ b/tests/test_hcservices_client.py
@@ -9,6 +9,7 @@ from httpx import Response
 from bharat_courts.captcha.base import CaptchaSolver
 from bharat_courts.config import BharatCourtsConfig
 from bharat_courts.courts import get_court
+from bharat_courts.hcservices import endpoints
 from bharat_courts.hcservices.client import HCServicesClient
 from bharat_courts.hcservices.endpoints import (
     CAPTCHA_IMAGE_URL,
@@ -54,3 +55,51 @@ async def test_case_status(fast_config, captcha_solver):
     assert len(results) == 2
     assert results[0].case_number == "WP(C)/12345/2024"
     assert results[0].court_name == "Delhi High Court"
+
+
+# ------------------------------------------------------------------
+# Advocate form builders
+# ------------------------------------------------------------------
+
+
+def test_advocate_form_by_name():
+    form = endpoints.case_status_by_advocate_form(
+        state_code="17", captcha="abc123", advocate_name="PRIYA SHARMA"
+    )
+    assert form["caseStatusSearchType"] == "CSAdvName"
+    assert form["search_type"] == "1"
+    assert form["advocate_name"] == "PRIYA SHARMA"
+    assert "adv_bar_state" not in form
+
+
+def test_advocate_form_by_bar_code():
+    form = endpoints.case_status_by_advocate_form(
+        state_code="17", captcha="abc123", bar_code="G/504/2011"
+    )
+    # NOT CSAdvNamebar -- sending that makes the server return ERROR_VAL
+    assert form["caseStatusSearchType"] == "CSAdvName"
+    assert form["search_type"] == "2"
+    assert form["adv_bar_state"] == "G/504/2011"
+    assert "advocate_name" not in form
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"advocate_name": "PRIYA SHARMA", "bar_code": "G/504/2011"},
+    ],
+)
+def test_advocate_form_requires_exactly_one_selector(kwargs):
+    with pytest.raises(ValueError):
+        endpoints.case_status_by_advocate_form(state_code="17", captcha="abc123", **kwargs)
+
+
+def test_advocate_cause_list_form():
+    form = endpoints.advocate_cause_list_form(
+        state_code="17", captcha="abc123", bar_code="G/504/2011", causelist_date="17-08-2026"
+    )
+    assert form["search_type"] == "3"
+    assert form["f"] == "date_case_list"
+    assert form["caselist_date_dmy"] == "17-08-2026"
+    assert form["adv_bar_state"] == "G/504/2011"

--- a/tests/test_hcservices_parser.py
+++ b/tests/test_hcservices_parser.py
@@ -244,3 +244,16 @@ def test_parse_advocate_cause_list_dedupe(hcservices_advocate_cause_list_json):
 def test_advocate_cause_list_empty_envelope():
     entries = parse_advocate_cause_list('{"con": [], "totRecords": 0, "Error": ""}')
     assert entries == []
+
+
+# Both dates ride on every row and mean different things: `date_next_list` is
+# the listing being queried, `todays_date` is when the matter was last in
+# court. Dropping the second loses the adjournment half of a diary entry.
+def test_advocate_cause_list_carries_both_dates(hcservices_advocate_cause_list_json):
+    from datetime import date
+
+    entries = parse_advocate_cause_list(hcservices_advocate_cause_list_json)
+    first = entries[0]
+    assert first.listing_date == date(2026, 8, 17)
+    assert first.business_date == date(2026, 8, 13)
+    assert first.listing_date != first.business_date

--- a/tests/test_hcservices_parser.py
+++ b/tests/test_hcservices_parser.py
@@ -6,6 +6,8 @@ import pytest
 
 from bharat_courts.hcservices.parser import (
     CaptchaError,
+    dedupe_by_cnr,
+    parse_advocate_cause_list,
     parse_case_status,
     parse_cause_list,
     parse_orders,
@@ -182,3 +184,63 @@ def test_parse_cause_list(hcservices_cause_list_html):
 
 def test_parse_cause_list_empty():
     assert parse_cause_list("<html></html>") == []
+
+
+# ------------------------------------------------------------------
+# Advocate search / advocate cause list
+# ------------------------------------------------------------------
+
+
+def test_parse_advocate_search_reuses_case_status(hcservices_advocate_search_json):
+    """Advocate search returns the same envelope as any other case search."""
+    results = parse_case_status(hcservices_advocate_search_json)
+    assert len(results) == 2
+
+    first = results[0]
+    assert first.cnr_number == "GJHC240100012024"
+    assert first.case_number == "1001/2024"
+    assert first.case_type == "FA"
+    assert first.petitioner == "ABC INDUSTRIES LTD"
+    # showRecords never populates status, whatever the search mode
+    assert first.status == ""
+
+
+def test_parse_advocate_cause_list(hcservices_advocate_cause_list_json):
+    entries = parse_advocate_cause_list(hcservices_advocate_cause_list_json)
+    # four rows, because the portal repeats a case once per party
+    assert len(entries) == 4
+
+    first = entries[0]
+    assert first.cnr_number == "GJHC240200012026"
+    assert first.case_number == "2001/2026"
+    assert first.case_type == "FA"
+    assert first.petitioner == "ABC INDUSTRIES LTD"
+    assert first.advocate_petitioner == "MS. PRIYA SHARMA(1234)"
+    assert first.purpose == "181-FOR FINAL DISPOSAL"
+    assert first.judge == "HONOURABLE MR.JUSTICE A B EXAMPLE"
+    # date_next_list arrives as ISO, unlike most portal dates
+    assert first.listing_date == date(2026, 8, 17)
+    # court_no is an internal establishment code, not a display-board number
+    assert first.court_number == "5377"
+    # no serial number is returned by this endpoint
+    assert first.item_number == ""
+    assert first.serial_number == 0
+
+
+def test_parse_advocate_cause_list_dedupe(hcservices_advocate_cause_list_json):
+    """Rows 2 and 3 share a CNR; dedupe collapses them to one case."""
+    entries = parse_advocate_cause_list(hcservices_advocate_cause_list_json)
+    cases = dedupe_by_cnr(entries)
+    assert len(cases) == 3
+    assert [c.cnr_number for c in cases] == [
+        "GJHC240200012026",
+        "GJHC240200022025",
+        "GJHC240200032024",
+    ]
+    # first row per CNR wins, so the first petitioner is kept
+    assert cases[1].petitioner == "FIRST PETITIONER"
+
+
+def test_advocate_cause_list_empty_envelope():
+    entries = parse_advocate_cause_list('{"con": [], "totRecords": 0, "Error": ""}')
+    assert entries == []


### PR DESCRIPTION
## Summary

Adds `case_status_by_cnr` for both portals, and fixes three defects that only surfaced once real cases were pulled through the library.

**Stacked on #24.** This branch is `feat/advocate-search` plus four commits, so the diff currently includes that PR's commit as well — GitHub cannot base a cross-fork PR on another fork's branch. Merge #24 first and this shrinks to the remaining four. Happy to rebase onto `main` afterwards if you'd rather review it flat.

## What it adds

`case_status_by_cnr(cnr) -> CaseDetail`, on `HCServicesClient` and `DistrictCourtClient`.

The search endpoints answer with identity only — `status` empty, `next_hearing_date` `None` — so getting a case's real state needed a second captcha-gated drill-down per case. A CNR lookup returns the whole page in one request: stage, coram, every party with advocates, the acts, the full hearing history and the orders.

Both portals answer with the same *page* rather than the JSON envelope search uses (HC returns the HTML directly, district wraps it in `casetype_list`), so one parser serves both. Where the markup differs it differs in column count, so layout is detected from row shape rather than a portal flag. Two class-name traps are handled: the acts table is `Acts_table` on HC and `acts_table` on district, and `transfer_table` means *Document Details* on HC but *case transfers* on district, so it is matched by heading rather than class.

## Three fixes

**The orders table leaked into case history.** Gujarat HC nests the orders table *inside* the history table, so both the row scan and the cell scan reached into it. `GJHC240464312025` came back with **22 hearings for a case that has 16** — the extra six being the orders header row and five rows whose purpose read "View".

The existing fixture placed the orders table as a *sibling*, which is precisely why this passed CI while failing live. The fixture now reproduces the portal's nesting, and both scans are bounded to their nearest ancestor.

**The cause list's second date was discarded.** Each row carries two: `date_next_list` is the listing being queried, `todays_date` is when the matter was last in court. On a board fetched for 20-08-2026, `todays_date` read 18-08-2026. They are not two names for the same day, and without the pair a caller cannot tell an adjournment from the hearing that produced it — so `CauseListEntry` gains `business_date`.

**Two documentation corrections, both load-bearing.**

Cause-list rows are a cross-product of parties *and judges*, not one per party as the docstring said. `GJHC240569342026` returned **8 rows for 4 petitioners before a 2-judge division bench**; a 14-row board was 4 actual matters. `dedupe_by_cnr` collapses both dimensions, so the row it keeps names one judge of the bench rather than the coram — worth stating rather than leaving to be discovered.

And the advice to filter a name search on the bracketed court id for an exact match **silently drops matters**. For `G/504/2011` that id rides on 6,666 rows, but 97 more — 64 further CNRs, all filed 2015 or earlier — carry the bare name with no id at all. Bar-code search needs no filtering: the portal resolves it and echoes the resolution back in `adv_name`.

## Verified live

Gujarat HC, advocate `G/504/2011`, 2026-08-20:

- `GJHC240464312025` — 16 history rows forming a clean adjournment chain (each row's `business_date` equal to the previous row's `hearing_date`), 5 orders, 4 respondents, 1 act
- that advocate's book — 6,763 rows across **2,779 matters**, CNR years 1993–2026
- one day's board — 14 rows across **4 matters**

Two portal behaviours confirmed rather than assumed, in case they save someone else the trip: `status` is never published — not on the case page, not in search results — so pending/disposed has to be derived from `date_of_decision`; and `item_number`/`serial_number` are always empty, because the serial exists only in a cause-list PDF that Gujarat HC does not serve.

## Tests

316 pass. New coverage for the nested-orders regression and for both cause-list dates. No new dependencies.