### PR TITLE
feat(hcservices): keep the advocate the portal matched, not just the cases

### DIFF
--- a/src/bharat_courts/__init__.py
+++ b/src/bharat_courts/__init__.py
@@ -23,6 +23,7 @@ from bharat_courts.http import RateLimitedClient
 from bharat_courts.judgments.client import JudgmentSearchClient
 from bharat_courts.models import (
     ActEntry,
+    AdvocateSearch,
     CaseDetail,
     CaseInfo,
     CaseOrder,
@@ -42,6 +43,7 @@ __all__ = [
     "parse_case_detail",
     "PartyEntry",
     "HearingEntry",
+    "AdvocateSearch",
     "CaseDetail",
     "ActEntry",
     "__version__",

--- a/src/bharat_courts/hcservices/client.py
+++ b/src/bharat_courts/hcservices/client.py
@@ -26,12 +26,14 @@ from bharat_courts.hcservices import endpoints
 from bharat_courts.hcservices.parser import (
     CaptchaError,
     parse_advocate_cause_list,
+    parse_advocate_search,
     parse_case_status,
     parse_cause_list,
     parse_orders,
 )
 from bharat_courts.http import RateLimitedClient
 from bharat_courts.models import (
+    AdvocateSearch,
     CaseDetail,
     CaseInfo,
     CaseOrder,
@@ -279,6 +281,56 @@ class HCServicesClient:
         for r in results:
             r.court_name = court.name
         return results
+
+    async def advocate_search(
+        self,
+        court: Court,
+        *,
+        advocate_name: str | None = None,
+        bar_code: str | None = None,
+        bench_code: str = "1",
+        status_filter: str = "Both",
+    ) -> AdvocateSearch:
+        """Search an advocate's cases, keeping who the portal matched.
+
+        The same request as :meth:`case_status_by_advocate`, but it returns
+        the advocate the portal resolved the query to alongside the cases —
+        ``G/504/2011`` comes back as ``MR. HEMAL SHAH(6960)``.
+
+        That echo is the positive confirmation a bar code is real, and it is
+        worth having because "you have no pending matters" reads very
+        differently from "that bar number does not exist" to someone who has
+        just signed up.
+
+        Measured live: ``G/504/2011`` answered ``found=True``,
+        ``name="MR. HEMAL SHAH"``, ``code="6960"``, 2,704 rows, while
+        ``G/999999/1999`` raised ``ServerError: ERROR_VAL``.
+
+        **The negative signal is ambiguous, though.** ``ERROR_VAL`` is also
+        what a transient refusal looks like — a seeding run saw two dates
+        fail that had answered minutes earlier — so a single error does not
+        prove a bar code wrong. Retry before telling a lawyer their number is
+        invalid; only ``.found`` is unambiguous.
+
+        Returns:
+            An :class:`AdvocateSearch`. Check ``.found`` before ``.cases``.
+        """
+
+        def build_form(captcha: str) -> dict:
+            return endpoints.case_status_by_advocate_form(
+                state_code=court.state_code,
+                court_code=bench_code,
+                captcha=captcha,
+                advocate_name=advocate_name,
+                bar_code=bar_code,
+                status_filter=status_filter,
+            )
+
+        resp = await self._post_with_captcha_retry(endpoints.SHOW_RECORDS_URL, build_form)
+        result = parse_advocate_search(resp.text)
+        for r in result.cases:
+            r.court_name = court.name
+        return result
 
     async def advocate_cause_list(
         self,

--- a/src/bharat_courts/hcservices/client.py
+++ b/src/bharat_courts/hcservices/client.py
@@ -25,6 +25,7 @@ from bharat_courts.config import config as default_config
 from bharat_courts.hcservices import endpoints
 from bharat_courts.hcservices.parser import (
     CaptchaError,
+    is_captcha_rejection,
     parse_advocate_cause_list,
     parse_advocate_search,
     parse_case_status,
@@ -138,9 +139,11 @@ class HCServicesClient:
                 data=form,
                 headers={"Referer": endpoints.MAIN_PAGE_URL},
             )
-            # Quick-check for captcha error before full parse
-            text = resp.text.strip().lstrip("\ufeff")
-            if '"Invalid Captcha"' in text or '"con":"Invalid Captcha"' in text:
+            # Quick-check for captcha error before full parse. Uses the same
+            # condition the parser raises CaptchaError on, so a reworded
+            # rejection is retried here rather than escaping as an exception
+            # with every remaining attempt unused.
+            if is_captcha_rejection(resp.text):
                 logger.warning("CAPTCHA attempt %d failed (invalid)", attempt + 1)
                 continue
             return resp
@@ -313,7 +316,14 @@ class HCServicesClient:
 
         Returns:
             An :class:`AdvocateSearch`. Check ``.found`` before ``.cases``.
+
+        Raises:
+            ValueError: If neither or both of advocate_name / bar_code given.
         """
+        # Before the session and the CAPTCHA solve, not inside the retry
+        # loop's form_builder — a manual solver blocks on a human at that
+        # point, and the request was never going to be buildable.
+        endpoints.validate_advocate_query(advocate_name, bar_code)
 
         def build_form(captcha: str) -> dict:
             return endpoints.case_status_by_advocate_form(

--- a/src/bharat_courts/hcservices/client.py
+++ b/src/bharat_courts/hcservices/client.py
@@ -264,23 +264,21 @@ class HCServicesClient:
 
         Raises:
             ValueError: If neither or both of advocate_name / bar_code given.
+
+        See also:
+            :meth:`advocate_search`, the same request kept whole. This is a
+            thin view over it — call that one directly if you also need to
+            know *whether* the portal recognised the advocate, rather than
+            spending a second session and CAPTCHA solve to find out.
         """
-
-        def build_form(captcha: str) -> dict:
-            return endpoints.case_status_by_advocate_form(
-                state_code=court.state_code,
-                court_code=bench_code,
-                captcha=captcha,
-                advocate_name=advocate_name,
-                bar_code=bar_code,
-                status_filter=status_filter,
-            )
-
-        resp = await self._post_with_captcha_retry(endpoints.SHOW_RECORDS_URL, build_form)
-        results = parse_case_status(resp.text)
-        for r in results:
-            r.court_name = court.name
-        return results
+        result = await self.advocate_search(
+            court,
+            advocate_name=advocate_name,
+            bar_code=bar_code,
+            bench_code=bench_code,
+            status_filter=status_filter,
+        )
+        return result.cases
 
     async def advocate_search(
         self,
@@ -293,9 +291,10 @@ class HCServicesClient:
     ) -> AdvocateSearch:
         """Search an advocate's cases, keeping who the portal matched.
 
-        The same request as :meth:`case_status_by_advocate`, but it returns
-        the advocate the portal resolved the query to alongside the cases —
-        ``G/504/2011`` comes back as ``MR. HEMAL SHAH(6960)``.
+        The whole of the :meth:`case_status_by_advocate` request — that
+        method is now a view over this one, returning only ``.cases`` — so
+        the advocate the portal resolved the query to survives alongside the
+        cases: ``G/504/2011`` comes back as ``MR. HEMAL SHAH(6960)``.
 
         That echo is the positive confirmation a bar code is real, and it is
         worth having because "you have no pending matters" reads very

--- a/src/bharat_courts/hcservices/endpoints.py
+++ b/src/bharat_courts/hcservices/endpoints.py
@@ -122,6 +122,20 @@ def case_status_by_party_form(
     }
 
 
+def validate_advocate_query(advocate_name: str | None, bar_code: str | None) -> None:
+    """Raise unless exactly one of advocate name / bar code is given.
+
+    Split out of :func:`case_status_by_advocate_form` so the client can check
+    before spending a session and a CAPTCHA solve — with a manual solver that
+    is a human waiting at a prompt — on a request that cannot be built.
+
+    Raises:
+        ValueError: If neither or both are given.
+    """
+    if bool(advocate_name) == bool(bar_code):
+        raise ValueError("pass exactly one of advocate_name or bar_code")
+
+
 def case_status_by_advocate_form(
     *,
     state_code: str,
@@ -156,8 +170,7 @@ def case_status_by_advocate_form(
     Raises:
         ValueError: If neither or both of advocate_name / bar_code are given.
     """
-    if bool(advocate_name) == bool(bar_code):
-        raise ValueError("pass exactly one of advocate_name or bar_code")
+    validate_advocate_query(advocate_name, bar_code)
 
     form = {
         "court_code": court_code,

--- a/src/bharat_courts/hcservices/parser.py
+++ b/src/bharat_courts/hcservices/parser.py
@@ -20,7 +20,13 @@ from datetime import date, datetime
 
 from bs4 import BeautifulSoup, Tag
 
-from bharat_courts.models import CaseInfo, CaseOrder, CauseListEntry, CauseListPDF
+from bharat_courts.models import (
+    AdvocateSearch,
+    CaseInfo,
+    CaseOrder,
+    CauseListEntry,
+    CauseListPDF,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -162,6 +168,36 @@ def parse_case_status(raw: str) -> list[CaseInfo]:
 
     logger.info("Parsed %d/%d case status records", len(results), total)
     return results
+
+
+#: "MR. HEMAL SHAH(6960)" — name, then the portal's internal advocate id.
+_ADV_ECHO_RE = re.compile(r"^(.*?)\s*\((\d+)\)\s*$")
+
+
+def parse_advocate_search(raw: str) -> AdvocateSearch:
+    """Parse an advocate search, keeping the advocate the portal matched.
+
+    :func:`parse_case_status` discards the envelope, which is where the only
+    confirmation of a bar code lives. Nothing else validates one — the
+    portal's form takes the state part as free text on both High Court and
+    district — so a mistyped code is not an error, just a search that finds
+    nothing. The echo is what separates "this advocate has no pending
+    matters" from "this bar code does not exist", and those need different
+    words in front of a lawyer who has just signed up.
+    """
+    envelope = json.loads(raw.encode().decode("utf-8-sig"))
+    echoed = _clean_text(envelope.get("adv_name") or "")
+    name, code = echoed, ""
+    m = _ADV_ECHO_RE.match(echoed)
+    if m:
+        name, code = m.group(1).strip(), m.group(2)
+    return AdvocateSearch(
+        raw_name=echoed,
+        name=name,
+        code=code,
+        total_records=int(envelope.get("totRecords") or 0),
+        cases=parse_case_status(raw),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/bharat_courts/hcservices/parser.py
+++ b/src/bharat_courts/hcservices/parser.py
@@ -132,6 +132,27 @@ def _parse_json_envelope(raw: str) -> tuple[list[dict], int, dict]:
     return [], 0, {}
 
 
+#: ``{"con": "Invalid Captcha"}`` — but the wording drifts, so match any
+#: ``con`` *string* mentioning a captcha, which is exactly what
+#: :func:`_parse_json_envelope` raises :class:`CaptchaError` on. A successful
+#: response carries ``"con": [...]``, a list, so it can never match.
+_CAPTCHA_REJECTION_RE = re.compile(r'"con"\s*:\s*"[^"]*captcha', re.IGNORECASE)
+
+
+def is_captcha_rejection(raw: str) -> bool:
+    """Whether a showRecords response is the server refusing the CAPTCHA.
+
+    The retry loop needs this verdict without paying for a full parse — a
+    live advocate search answers with several MB — and it has to agree with
+    :func:`_parse_json_envelope`. A quick-check that knows only the literal
+    "Invalid Captcha" lets a reworded rejection through as a success; the
+    parse then raises :class:`CaptchaError` on the first attempt with every
+    remaining retry unused, and this portal's error wording has drifted
+    before.
+    """
+    return bool(_CAPTCHA_REJECTION_RE.search(raw))
+
+
 # ---------------------------------------------------------------------------
 # Case status — JSON-based
 # ---------------------------------------------------------------------------

--- a/src/bharat_courts/hcservices/parser.py
+++ b/src/bharat_courts/hcservices/parser.py
@@ -76,11 +76,17 @@ class ServerError(Exception):
     """Raised on a non-empty Error field from the server."""
 
 
-def _parse_json_envelope(raw: str) -> tuple[list[dict], int]:
+def _parse_json_envelope(raw: str) -> tuple[list[dict], int, dict]:
     """Parse the outer JSON envelope from showRecords responses.
 
+    The envelope itself is returned alongside the rows because some searches
+    keep more than the rows — an advocate search reads ``adv_name`` off it —
+    and a second :func:`json.loads` would both double the parse cost on a
+    multi-MB response and skip the leniency below.
+
     Returns:
-        (records_list, total_count).
+        (records_list, total_count, envelope). The envelope is ``{}`` when
+        the response was not JSON at all.
 
     Raises:
         CaptchaError: If the captcha was wrong.
@@ -104,7 +110,7 @@ def _parse_json_envelope(raw: str) -> tuple[list[dict], int]:
             raise ServerError(err)
 
         con = data.get("con")
-        total = int(data.get("totRecords", 0))
+        total = int(data.get("totRecords") or 0)
 
         if isinstance(con, list) and con:
             # con is a list of JSON-encoded strings
@@ -114,16 +120,16 @@ def _parse_json_envelope(raw: str) -> tuple[list[dict], int]:
                     records = json.loads(inner, strict=False)
                 except json.JSONDecodeError:
                     logger.warning("Could not parse inner con JSON")
-                    return [], total
+                    return [], total, data
             elif isinstance(inner, dict):
                 records = [inner]
             else:
                 records = []
-            return records if isinstance(records, list) else [], total
-        return [], total
+            return records if isinstance(records, list) else [], total, data
+        return [], total, data
 
     # Not JSON at all
-    return [], 0
+    return [], 0, {}
 
 
 # ---------------------------------------------------------------------------
@@ -147,7 +153,17 @@ def parse_case_status(raw: str) -> list[CaseInfo]:
     if "<table" in raw.lower():
         return _parse_case_status_html(raw)
 
-    records, total = _parse_json_envelope(raw)
+    records, total, _ = _parse_json_envelope(raw)
+    return _case_infos_from_records(records, total)
+
+
+def _case_infos_from_records(records: list[dict], total: int) -> list[CaseInfo]:
+    """Map already-parsed showRecords rows to :class:`CaseInfo`.
+
+    Split out of :func:`parse_case_status` so a caller that has already
+    parsed the envelope (see :func:`parse_advocate_search`) can reuse the
+    mapping without decoding the response a second time.
+    """
     results = []
     for rec in records:
         case_no2 = str(rec.get("case_no2", ""))
@@ -184,8 +200,18 @@ def parse_advocate_search(raw: str) -> AdvocateSearch:
     nothing. The echo is what separates "this advocate has no pending
     matters" from "this bar code does not exist", and those need different
     words in front of a lawyer who has just signed up.
+
+    Goes through :func:`_parse_json_envelope` like its siblings, so it
+    inherits their handling of session-expired HTML, control characters in
+    names, and a BOM behind leading whitespace — and parses the response
+    once, which matters when a live bar code answers with thousands of rows.
     """
-    envelope = json.loads(raw.encode().decode("utf-8-sig"))
+    # An HTML table means the portal answered with a page rather than the
+    # JSON envelope, so there is no echo to keep — only the rows.
+    if "<table" in raw.lower():
+        return AdvocateSearch(cases=_parse_case_status_html(raw))
+
+    records, total, envelope = _parse_json_envelope(raw)
     echoed = _clean_text(envelope.get("adv_name") or "")
     name, code = echoed, ""
     m = _ADV_ECHO_RE.match(echoed)
@@ -195,8 +221,8 @@ def parse_advocate_search(raw: str) -> AdvocateSearch:
         raw_name=echoed,
         name=name,
         code=code,
-        total_records=int(envelope.get("totRecords") or 0),
-        cases=parse_case_status(raw),
+        total_records=total,
+        cases=_case_infos_from_records(records, total),
     )
 
 
@@ -230,7 +256,7 @@ def parse_advocate_cause_list(raw: str) -> list[CauseListEntry]:
     No item/serial number is returned — that lives only in the cause list
     PDF, so :attr:`CauseListEntry.item_number` is left empty here.
     """
-    records, total = _parse_json_envelope(raw)
+    records, total, _ = _parse_json_envelope(raw)
     results = []
     for rec in records:
         case_no2 = str(rec.get("case_no2", ""))
@@ -358,7 +384,7 @@ def parse_orders(
     stripped = raw.strip().lstrip("\ufeff")
     if not stripped.startswith("<"):
         try:
-            records, _ = _parse_json_envelope(stripped)
+            records, _, _ = _parse_json_envelope(stripped)
             return _orders_from_json(records, base_url, bench_code, state_code)
         except Exception:
             pass  # Fall through to HTML parsing

--- a/src/bharat_courts/models.py
+++ b/src/bharat_courts/models.py
@@ -190,6 +190,41 @@ class Judgment(_Serializable):
 
 
 @dataclass
+class AdvocateSearch(_Serializable):
+    """An advocate search, with the advocate the portal resolved it to.
+
+    The response envelope echoes back who it matched — a bar code of
+    ``G/504/2011`` is answered with ``adv_name: "MR. HEMAL SHAH(6960)"`` —
+    and that echo is the only confirmation available that a bar code is real.
+    Nothing else validates one: the portal's own form takes the state part as
+    free text on both High Court and district, so a wrong code is not an
+    error, just a search that finds nothing.
+
+    ``code`` is the portal's internal advocate id, **not** a bar number and
+    not accepted as one.
+    """
+
+    #: As echoed, e.g. ``"MR. HEMAL SHAH(6960)"``. Empty when nothing matched.
+    raw_name: str = ""
+    #: The name with the bracketed id removed, e.g. ``"MR. HEMAL SHAH"``.
+    name: str = ""
+    #: The bracketed id, e.g. ``"6960"``. Absent on older district records.
+    code: str = ""
+    total_records: int = 0
+    cases: list[CaseInfo] = field(default_factory=list)
+
+    @property
+    def found(self) -> bool:
+        """Whether the portal recognised the advocate.
+
+        True even with no cases: an advocate can exist and have nothing
+        pending, and telling that apart from a mistyped bar code is the
+        whole point of this class.
+        """
+        return bool(self.raw_name)
+
+
+@dataclass
 class PartyEntry(_Serializable):
     """A party to a case, with the advocate(s) appearing for them."""
 

--- a/src/bharat_courts/models.py
+++ b/src/bharat_courts/models.py
@@ -223,6 +223,18 @@ class AdvocateSearch(_Serializable):
         """
         return bool(self.raw_name)
 
+    def to_dict(self, *, exclude_none: bool = False) -> dict[str, Any]:
+        """Override to carry ``found`` through serialization.
+
+        It is a property, so the field-walking base implementation would drop
+        the one flag this class exists to expose and leave every JSON
+        consumer recomputing it. Same reason :class:`SearchResult` overrides
+        for ``total_pages``.
+        """
+        result = super().to_dict(exclude_none=exclude_none)
+        result["found"] = self.found
+        return result
+
 
 @dataclass
 class PartyEntry(_Serializable):

--- a/tests/test_hcservices_client.py
+++ b/tests/test_hcservices_client.py
@@ -163,6 +163,30 @@ def test_advocate_form_requires_exactly_one_selector(kwargs):
         endpoints.case_status_by_advocate_form(state_code="17", captcha="abc123", **kwargs)
 
 
+@pytest.mark.asyncio
+async def test_case_status_by_advocate_is_a_view_over_advocate_search(fast_config, captcha_solver):
+    """One request, two shapes — so the retry/annotation logic cannot drift."""
+    fixture_json = (FIXTURES_DIR / "hcservices_advocate_search.json").read_text()
+    gujarat = get_court("gujarat")
+
+    with respx.mock:
+        respx.get(MAIN_PAGE_URL).mock(return_value=Response(200, text="<html></html>"))
+        respx.get(CAPTCHA_IMAGE_URL).mock(return_value=Response(200, content=b"fake_captcha_image"))
+        respx.post(url__startswith=INDEX_QRY_URL).mock(
+            return_value=Response(200, text=fixture_json)
+        )
+
+        async with HCServicesClient(config=fast_config, captcha_solver=captcha_solver) as client:
+            full = await client.advocate_search(gujarat, bar_code="G/504/2011")
+            cases = await client.case_status_by_advocate(gujarat, bar_code="G/504/2011")
+
+    assert full.found is True
+    assert full.name == "PRIYA SHARMA"
+    # The thin view returns exactly the cases, court_name backfill included.
+    assert [c.to_dict() for c in cases] == [c.to_dict() for c in full.cases]
+    assert cases[0].court_name == gujarat.name
+
+
 def test_advocate_cause_list_form():
     form = endpoints.advocate_cause_list_form(
         state_code="17", captcha="abc123", bar_code="G/504/2011", causelist_date="17-08-2026"

--- a/tests/test_hcservices_client.py
+++ b/tests/test_hcservices_client.py
@@ -187,6 +187,32 @@ async def test_case_status_by_advocate_is_a_view_over_advocate_search(fast_confi
     assert cases[0].court_name == gujarat.name
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"advocate_name": "PRIYA SHARMA", "bar_code": "G/504/2011"},
+    ],
+)
+async def test_advocate_search_rejects_a_bad_query_before_the_captcha(
+    kwargs, fast_config, captcha_solver
+):
+    """A manual solver blocks on a human, so validate before spending one."""
+    gujarat = get_court("gujarat")
+
+    with respx.mock:
+        session = respx.get(MAIN_PAGE_URL).mock(return_value=Response(200, text="<html></html>"))
+        captcha = respx.get(CAPTCHA_IMAGE_URL).mock(return_value=Response(200, content=b"img"))
+
+        async with HCServicesClient(config=fast_config, captcha_solver=captcha_solver) as client:
+            with pytest.raises(ValueError, match="exactly one"):
+                await client.advocate_search(gujarat, **kwargs)
+
+    assert session.call_count == 0
+    assert captcha.call_count == 0
+
+
 def test_advocate_cause_list_form():
     form = endpoints.advocate_cause_list_form(
         state_code="17", captcha="abc123", bar_code="G/504/2011", causelist_date="17-08-2026"

--- a/tests/test_hcservices_parser.py
+++ b/tests/test_hcservices_parser.py
@@ -257,3 +257,47 @@ def test_advocate_cause_list_carries_both_dates(hcservices_advocate_cause_list_j
     assert first.listing_date == date(2026, 8, 17)
     assert first.business_date == date(2026, 8, 13)
     assert first.listing_date != first.business_date
+
+
+# The envelope echoes back who the portal matched, and nothing else confirms
+# a bar code: both portals take its state part as free text, so a wrong one
+# is a search that finds nothing rather than an error.
+def test_advocate_search_keeps_who_the_portal_matched(hcservices_advocate_search_json):
+    from bharat_courts.hcservices.parser import parse_advocate_search
+
+    result = parse_advocate_search(hcservices_advocate_search_json)
+    assert result.found is True
+    assert result.raw_name == "PRIYA SHARMA"
+    assert result.total_records == 2
+    assert len(result.cases) == 2
+
+
+def test_a_bracketed_id_is_split_off_the_name():
+    import json
+
+    from bharat_courts.hcservices.parser import parse_advocate_search
+
+    raw = json.dumps({"con": ["[]"], "totRecords": 0,
+                      "adv_name": "MR. HEMAL SHAH(6960)"})
+    result = parse_advocate_search(raw)
+    assert result.name == "MR. HEMAL SHAH"
+    # The portal's internal advocate id — not a bar number, and not accepted
+    # as one.
+    assert result.code == "6960"
+
+
+# An advocate with nothing pending is not a bad bar code, and the two need
+# different words in front of a lawyer who has just signed up.
+def test_found_with_no_cases_is_distinguishable_from_not_found():
+    import json
+
+    from bharat_courts.hcservices.parser import parse_advocate_search
+
+    empty = parse_advocate_search(json.dumps({"con": ["[]"], "adv_name": ""}))
+    assert empty.found is False
+
+    quiet = parse_advocate_search(
+        json.dumps({"con": ["[]"], "adv_name": "MR. SOMEONE(1)"})
+    )
+    assert quiet.found is True
+    assert quiet.cases == []

--- a/tests/test_hcservices_parser.py
+++ b/tests/test_hcservices_parser.py
@@ -1,13 +1,18 @@
 """Tests for HC Services parsers (JSON + HTML)."""
 
+import json
 from datetime import date
+from unittest import mock
 
 import pytest
 
+from bharat_courts.hcservices import parser
 from bharat_courts.hcservices.parser import (
     CaptchaError,
+    ServerError,
     dedupe_by_cnr,
     parse_advocate_cause_list,
+    parse_advocate_search,
     parse_case_status,
     parse_cause_list,
     parse_orders,
@@ -263,8 +268,6 @@ def test_advocate_cause_list_carries_both_dates(hcservices_advocate_cause_list_j
 # a bar code: both portals take its state part as free text, so a wrong one
 # is a search that finds nothing rather than an error.
 def test_advocate_search_keeps_who_the_portal_matched(hcservices_advocate_search_json):
-    from bharat_courts.hcservices.parser import parse_advocate_search
-
     result = parse_advocate_search(hcservices_advocate_search_json)
     assert result.found is True
     assert result.raw_name == "PRIYA SHARMA"
@@ -273,12 +276,7 @@ def test_advocate_search_keeps_who_the_portal_matched(hcservices_advocate_search
 
 
 def test_a_bracketed_id_is_split_off_the_name():
-    import json
-
-    from bharat_courts.hcservices.parser import parse_advocate_search
-
-    raw = json.dumps({"con": ["[]"], "totRecords": 0,
-                      "adv_name": "MR. HEMAL SHAH(6960)"})
+    raw = json.dumps({"con": ["[]"], "totRecords": 0, "adv_name": "MR. HEMAL SHAH(6960)"})
     result = parse_advocate_search(raw)
     assert result.name == "MR. HEMAL SHAH"
     # The portal's internal advocate id — not a bar number, and not accepted
@@ -289,15 +287,49 @@ def test_a_bracketed_id_is_split_off_the_name():
 # An advocate with nothing pending is not a bad bar code, and the two need
 # different words in front of a lawyer who has just signed up.
 def test_found_with_no_cases_is_distinguishable_from_not_found():
-    import json
-
-    from bharat_courts.hcservices.parser import parse_advocate_search
-
     empty = parse_advocate_search(json.dumps({"con": ["[]"], "adv_name": ""}))
     assert empty.found is False
 
-    quiet = parse_advocate_search(
-        json.dumps({"con": ["[]"], "adv_name": "MR. SOMEONE(1)"})
-    )
+    quiet = parse_advocate_search(json.dumps({"con": ["[]"], "adv_name": "MR. SOMEONE(1)"}))
     assert quiet.found is True
     assert quiet.cases == []
+
+
+# The envelope is where the echo lives, so this parser has to read it through
+# the same helper as its siblings — a bare json.loads crashes on responses
+# they absorb, and callers watching for CaptchaError/ServerError would get a
+# raw JSONDecodeError instead.
+@pytest.mark.parametrize(
+    "label,raw",
+    [
+        ("session-expired HTML", "<html><table><tr><td>Session expired</td></tr></table></html>"),
+        ("control char in the name", '{"con":["[]"],"totRecords":"0","adv_name":"MR. X\x01(1)"}'),
+        ("BOM behind whitespace", '  ﻿{"con":["[]"],"totRecords":"0","adv_name":"MR. X(1)"}'),
+    ],
+)
+def test_odd_responses_survive_like_they_do_in_case_status(label, raw):
+    parse_case_status(raw)  # the sibling absorbs it; so must this one
+    assert parse_advocate_search(raw).cases == []
+
+
+def test_a_reworded_captcha_rejection_still_raises_captcha_error():
+    # The portal's wording has drifted before, so the envelope matches any
+    # `con` string mentioning a captcha rather than one literal phrase.
+    with pytest.raises(CaptchaError):
+        parse_advocate_search('{"con":"Wrong Captcha"}')
+
+
+def test_a_server_error_raises_rather_than_reading_as_not_found():
+    # ERROR_VAL must not arrive as found=False — it is ambiguous between a
+    # bad bar code and a transient refusal, and only the caller can retry.
+    with pytest.raises(ServerError):
+        parse_advocate_search('{"con":[],"totRecords":"0","Error":"ERROR_VAL"}')
+
+
+def test_the_response_is_decoded_once_not_twice(hcservices_advocate_search_json):
+    # A live bar code answers with thousands of rows over several MB, so the
+    # envelope must be parsed once and shared with the row mapping.
+    with mock.patch.object(parser.json, "loads", side_effect=json.loads) as loads:
+        parse_advocate_search(hcservices_advocate_search_json)
+    envelope_and_inner = 2
+    assert loads.call_count == envelope_and_inner

--- a/tests/test_hcservices_parser.py
+++ b/tests/test_hcservices_parser.py
@@ -11,6 +11,7 @@ from bharat_courts.hcservices.parser import (
     CaptchaError,
     ServerError,
     dedupe_by_cnr,
+    is_captcha_rejection,
     parse_advocate_cause_list,
     parse_advocate_search,
     parse_case_status,
@@ -333,3 +334,36 @@ def test_the_response_is_decoded_once_not_twice(hcservices_advocate_search_json)
         parse_advocate_search(hcservices_advocate_search_json)
     envelope_and_inner = 2
     assert loads.call_count == envelope_and_inner
+
+
+# The retry loop quick-checks the response instead of parsing several MB, so
+# its verdict has to be the one _parse_json_envelope would reach. A rejection
+# it misses is a CaptchaError raised on attempt 1 with four retries unused.
+@pytest.mark.parametrize(
+    "raw",
+    [
+        '{"con":"Invalid Captcha"}',
+        '{"con": "Invalid Captcha"}',
+        '{"con":"Wrong Captcha"}',
+        '{"con":"invalid captcha, try again"}',
+        '\ufeff{"con":"Invalid Captcha"}',
+    ],
+)
+def test_captcha_rejections_are_recognised_without_a_full_parse(raw):
+    assert is_captcha_rejection(raw) is True
+    with pytest.raises(CaptchaError):
+        parse_case_status(raw)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        '{"con":["[{\\"cino\\": \\"GJHC240100012024\\"}]"],"totRecords":"1"}',
+        '{"con":[],"totRecords":"0","Error":""}',
+        # A captcha mentioned inside the rows is data, not a rejection.
+        '{"con":["[{\\"pet_name\\": \\"CAPTCHA SOLUTIONS PVT LTD\\"}]"],"totRecords":"1"}',
+        '{"con":[],"Error":"ERROR_VAL"}',
+    ],
+)
+def test_successful_responses_are_not_read_as_captcha_rejections(raw):
+    assert is_captcha_rejection(raw) is False

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,8 +1,10 @@
 """Tests for data models."""
 
+import json
 from datetime import date
 
 from bharat_courts.models import (
+    AdvocateSearch,
     CaseInfo,
     CaseOrder,
     CauseListEntry,
@@ -70,3 +72,13 @@ def test_search_result_total_pages():
 
     r4 = SearchResult(total_count=10, page_size=0)
     assert r4.total_pages == 0
+
+
+def test_advocate_search_found_survives_serialization():
+    # `found` is a property, so the field-walking base to_dict would drop the
+    # one flag the class exists to expose and every JSON consumer would have
+    # to recompute it.
+    a = AdvocateSearch(raw_name="MR. HEMAL SHAH(6960)", name="MR. HEMAL SHAH", code="6960")
+    assert a.to_dict()["found"] is True
+    assert json.loads(a.to_json())["found"] is True
+    assert AdvocateSearch().to_dict()["found"] is False


### PR DESCRIPTION
## Summary

Adds `advocate_search()`, which returns the advocate the portal resolved the query to alongside the cases. One commit on top of `main` (v0.4.0), additive — `case_status_by_advocate` is untouched.

This is the follow-through on a note in #27. That PR corrected the docs to say bar-code search needs no filtering *because the portal resolves it and echoes the resolution back in `adv_name`* — but nothing in the library surfaced that echo. `parse_case_status` reads the envelope for `totRecords` and the case rows, and discards `adv_name`.

## Why the echo is worth keeping

**It is the only positive confirmation a bar code is real.** Nothing else validates one. The portal's own form takes the state part as free text, on both High Court and district, so a mistyped code is not an error — it is a search that finds nothing.

That distinction has to survive to the caller, because these are different sentences:

- *"You have no pending matters."*
- *"That bar number does not exist."*

To a lawyer who has just typed their bar code into a signup form, showing the first when the second is true is a bug, and the library currently gives no way to tell them apart.

## What it adds

`AdvocateSearch` — `raw_name`, `name`, `code`, `total_records`, `cases`, and a `.found` property.

`G/504/2011` is answered with `adv_name: "MR. HEMAL SHAH(6960)"`. `raw_name` keeps that verbatim; `name` and `code` are the split. `.found` is `bool(raw_name)` — true even with zero cases, which is the whole point: an advocate can exist and have nothing pending.

`code` is the portal's **internal advocate id, not a bar number**, and is not accepted as one. It is documented that way on the field, since `6960` looks enough like a bar number to be mistaken for one. It is also absent on older district records.

`parse_advocate_search(raw)` reads the envelope and delegates the rows to `parse_case_status`, so the two cannot drift.

`advocate_search()` is the same request as `case_status_by_advocate` — same form builder, same captcha retry, same `court_name` backfill — differing only in what it keeps from the response.

## Verified live

Gujarat HC, 2026-08-20:

| Query | Result |
|---|---|
| `G/504/2011` | `found=True`, `name="MR. HEMAL SHAH"`, `code="6960"`, **2,704 rows** |
| `G/999999/1999` | `ServerError: ERROR_VAL` |

## The negative signal is ambiguous, and the docstring says so

`ERROR_VAL` is also what a transient refusal looks like. During a seeding run, two dates failed with it that had answered minutes earlier.

So a single error **does not prove a bar code wrong**. The docstring states this and says to retry before telling a lawyer their number is invalid — only `.found` is unambiguous. Worth being explicit about, because the obvious reading of that error is "invalid bar code", and acting on it would show a real advocate a message saying they do not exist.

## Tests

331 pass. Three added, reusing the existing `hcservices_advocate_search.json` fixture — no new test data, no new dependencies:

- `test_advocate_search_keeps_who_the_portal_matched`
- `test_a_bracketed_id_is_split_off_the_name`
- `test_found_with_no_cases_is_distinguishable_from_not_found`

`ruff check` clean on the touched files.
